### PR TITLE
Add early resource loading from a list of dynamic asset paths

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/RRGameSingleton.cpp
@@ -9,9 +9,9 @@
 // RapyutaSim
 #include "Tools/RRTypeUtils.h"
 
-TMap<ERRResourceDataType, const TCHAR*> URRGameSingleton::SASSET_OWNING_MODULE_NAMES = {
-    {ERRResourceDataType::UE_STATIC_MESH, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME},
-    {ERRResourceDataType::UE_MATERIAL, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}};
+TMap<ERRResourceDataType, TArray<const TCHAR*>> URRGameSingleton::SASSET_OWNING_MODULE_NAMES = {
+    {ERRResourceDataType::UE_STATIC_MESH, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
+    {ERRResourceDataType::UE_MATERIAL, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}}};
 
 URRGameSingleton::URRGameSingleton(){
     UE_LOG(LogRapyutaCore, Display, TEXT("[RR GAME SINGLETON] INSTANTIATED! ======================"))}

--- a/Source/RapyutaSimulationPlugins/Private/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/RRGameSingleton.cpp
@@ -69,6 +69,10 @@ bool URRGameSingleton::InitializeResources()
     GetSimResourceInfo(dataType).HasBeenAllLoaded = false;
     verify(RequestResourcesLoading(dataType));
 
+    // [RUNTIME MESH] --
+    // (NOTE) These resources are dynamically loaded at run-time
+    GetSimResourceInfo(ERRResourceDataType::UE_RUNTIME_MESH).HasBeenAllLoaded = true;
+
     // [MATERIAL] --
     dataType = ERRResourceDataType::UE_MATERIAL;
     CollateAssetsInfo<UMaterialInterface>(dataType, FOLDER_PATH_ASSET_MATERIALS);

--- a/Source/RapyutaSimulationPlugins/Public/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/RRGameSingleton.h
@@ -41,9 +41,15 @@ public:
     {
         FRRResourceInfo& outResourceInfo = GetSimResourceInfo(InDataType);
 
-        TArray<FAssetData> assetDataList;
-        URRAssetUtils::LoadAssetDataList<T>(GetDynamicAssetsPath(InDataType) / InAssetRelativeFolderPath, assetDataList);
-        for (const auto& asset : assetDataList)
+        TArray<FAssetData> totalAssetDataList;
+        for (const auto& assetsPath : GetDynamicAssetsPathList(InDataType))
+        {
+            TArray<FAssetData> assetDataList;
+            URRAssetUtils::LoadAssetDataList<T>(assetsPath / InAssetRelativeFolderPath, assetDataList);
+            totalAssetDataList.Append(assetDataList);
+        }
+
+        for (const auto& asset : totalAssetDataList)
         {
             UE_LOG(LogTemp,
                    VeryVerbose,
@@ -54,16 +60,17 @@ public:
                    *asset.ToSoftObjectPath().ToString());
             outResourceInfo.AddResource(asset.AssetName.ToString(), asset.ToSoftObjectPath().ToString(), nullptr);
         }
-        return (assetDataList.Num() > 0);
+        return (totalAssetDataList.Num() > 0);
     }
 
     // ASSETS --
     // This list specifically hosts names of which module houses the UE assets based on their data type
-    static TMap<ERRResourceDataType, const TCHAR*> SASSET_OWNING_MODULE_NAMES;
+    static TMap<ERRResourceDataType, TArray<const TCHAR*>> SASSET_OWNING_MODULE_NAMES;
 
     // This only returns base path of assets residing in Plugin, not from Project level, which should starts with [/Game/]
     // And please note that the Sim does not store assets in Project, just to make them accessible among plugins.
     static constexpr const TCHAR* ASSETS_ROOT_PATH = TEXT("/");
+    static constexpr const TCHAR* ASSETS_PROJECT_MODULE_NAME = TEXT("Game/RapyutaContents");
     static FString GetAssetsBasePath(const TCHAR* InModuleName)
     {
         // For particular handling, please set the asset path ending with '/'
@@ -72,10 +79,14 @@ public:
     }
 
     static constexpr const TCHAR* DYNAMIC_CONTENTS_FOLDER_NAME = TEXT("DynamicContents");
-    static FString GetDynamicAssetsPath(const ERRResourceDataType InDataType)
+    static TArray<FString> GetDynamicAssetsPathList(const ERRResourceDataType InDataType)
     {
-        static FString runtimeAssetsPath = GetAssetsBasePath(SASSET_OWNING_MODULE_NAMES[InDataType]) / DYNAMIC_CONTENTS_FOLDER_NAME;
-        return runtimeAssetsPath;
+        static TArray<FString> runtimeAssetsPathList;
+        for (const auto& moduleName : SASSET_OWNING_MODULE_NAMES[InDataType])
+        {
+            runtimeAssetsPathList.Emplace(GetAssetsBasePath(moduleName) / DYNAMIC_CONTENTS_FOLDER_NAME);
+        }
+        return runtimeAssetsPathList;
     }
 
     //  RESOURCE STORE --
@@ -209,6 +220,7 @@ public:
 
     // Here we only define specially used materials for some specific purpose!
     static constexpr const TCHAR* MATERIAL_NAME_FLOOR = TEXT("M_FloorMat");
+    static constexpr const TCHAR* MATERIAL_NAME_BASE = TEXT("M_Base");
 
     UFUNCTION()
     FORCEINLINE UMaterialInterface* GetMaterial(const FString& InMaterialName)

--- a/Source/RapyutaSimulationPlugins/Public/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/RRGameSingleton.h
@@ -168,7 +168,8 @@ public:
         // Update [ResourceMap] with dynamically runtime-generated [InResourceObject]
         // of which soft object path is also created on the fly.
         FRRResourceInfo& resourceInfo = GetSimResourceInfo(InDataType);
-        resourceInfo.AddResource(InResourceUniqueName, FSoftObjectPath(InResourceUniqueName), InResourceObject);
+        // (Note) FSoftObjectPath only accepts legit package names, not [InResourceUniqueName] like an arbitrary one
+        resourceInfo.AddResource(InResourceUniqueName, FSoftObjectPath(InResourceObject), InResourceObject);
         resourceInfo.HasBeenAllLoaded = true;
 
         UE_LOG(LogTemp,

--- a/Source/RapyutaSimulationPlugins/Public/RRObjectCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/RRObjectCommon.h
@@ -20,6 +20,7 @@ enum class ERRResourceDataType : uint8
     NONE,
     // UASSET --
     UE_STATIC_MESH,
+    UE_RUNTIME_MESH,
     UE_MATERIAL,
 
     TOTAL


### PR DESCRIPTION
## Overview
Previously, Sim only did early loading for asset resources that reside under `RapyutaSimulationPlugins`, which pose certain limitations for client projects which could also house project-level dynamic assets.
Thus this PR enables Sim to load dynamic contents from various modules, either plugins or projects.

## Implementation Details
[RRGameSingleton]:
- [x] Update `SASSET_OWNING_MODULE_NAMES`'s type to `TMap<ERRResourceDataType, TArray<const TCHAR*>> which could house a list aof modules names (project, plugin names) for each resource data type.
- [x] `FString GetDynamicAssetsPath(const ERRResourceDataType InDataType)`-> `TArray<FString> GetDynamicAssetsPathList(const ERRResourceDataType InDataType)`
- [x] `CollateAssetsInfo()` load assets from a list of module asset paths
- [x] Add `AddDynamicResource()` allowing Sim to add resources dynamically created at runtime (like [RuntimeMesh](https://github.com/TriAxis-Games/RuntimeMeshComponent/blob/master/Source/RuntimeMeshComponent/Public/RuntimeMesh.h)) to the resource store, which could be reused for later robot link mesh creation.

## Risk
Currently, both `io_amr_UE, turtlebot3_UE` don't use early resource loading yet, thus this should not make any impact.