### PR TITLE
[ROS2ClockPublisher] Correct Clock time

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Tools/ROS2ClockPublisher.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/ROS2ClockPublisher.cpp
@@ -17,5 +17,6 @@ void UROS2ClockPublisher::InitializeWithROS2(AROS2Node* InROS2Node)
 
 void UROS2ClockPublisher::UpdateMessage(UROS2GenericMsg* InMessage)
 {
-    CastChecked<UROS2ClockMsg>(InMessage)->Update(FApp::GetDeltaTime());
+    // Noted: Elapsed time: time in seconds since world was brought up for play
+    CastChecked<UROS2ClockMsg>(InMessage)->Update(UGameplayStatics::GetTimeSeconds(GetWorld()));
 }


### PR DESCRIPTION
The newly added `UROS2ClockPublisher` has its **elapsed time** passed to ClockMessage update as delta time, while it is expected to be app's time in seconds since world was brought up for play.