### PR TITLE
[ATurtlebotROSController::MovementCallback()] Rollback to handle case of controller being garbaged

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/RRROS2GameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/RRROS2GameMode.cpp
@@ -27,4 +27,5 @@ void ARRROS2GameMode::BeginPlay()
     // Simulation state
     SimulationState = currentWorld->SpawnActor<ASimulationState>();
     SimulationState->ROSServiceNode = ROS2Node;
+    SimulationState->Init();
 }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/Turtlebot3/TurtlebotROSController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/Turtlebot3/TurtlebotROSController.cpp
@@ -125,13 +125,15 @@ void ATurtlebotROSController::MovementCallback(const UROS2GenericMsg* Msg)
         const FVector linear(ConversionUtils::VectorROSToUE(Output.linear));
         const FVector angular(ConversionUtils::RotationROSToUE(Output.angular));
 
+        // (Note) In this callback, which is invoked from ROS, the ROSController itself (this) could have been garbage collected,
+        // thus any direct referencing to its member in the lambda needs to be verified.
         AsyncTask(ENamedThreads::GameThread,
-                  [this, linear, angular]
+                  [linear, angular, vehicle = Turtlebot]
                   {
-                      if (IsValid(Turtlebot))
+                      if (IsValid(vehicle))
                       {
-                          Turtlebot->SetLinearVel(linear);
-                          Turtlebot->SetAngularVel(angular);
+                          vehicle->SetLinearVel(linear);
+                          vehicle->SetAngularVel(angular);
                       }
                   });
     }


### PR DESCRIPTION
https://github.com/rapyuta-robotics/io_amr_UE/pull/44#issuecomment-998520928
"Controllers can be transient. They typically aren't, but if you Posess() an AI, it will swap out the AI controller with a PlayerController. Or vice versa. In a game there are other times when you might switch out the controller, too. The ROS callback pushes a task onto the game thread to execute, but it doesn't guarantee order. So it could receive that callback during a Tick which destroys the controller, then the next Tick the async task runs with a garbage pointer. So yeah, my recommendation is to revert.", said @chalice-graeme 