### PR TITLE
Add early ros2 start

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/RRROS2GameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/RRROS2GameMode.cpp
@@ -2,6 +2,9 @@
 
 #include "RRROS2GameMode.h"
 
+// UE
+#include "HAL/PlatformMisc.h"
+
 // rclUE
 #include "Msgs/ROS2ClockMsg.h"
 #include "ROS2Node.h"
@@ -10,9 +13,39 @@
 #include "Tools/RRROS2ClockPublisher.h"
 #include "Tools/SimulationState.h"
 
-void ARRROS2GameMode::BeginPlay()
+void ARRROS2GameMode::InitGame(const FString& InMapName, const FString& InOptions, FString& OutErrorMessage)
 {
-    Super::BeginPlay();
+    Super::InitGame(InMapName, InOptions, OutErrorMessage);
+    UE_LOG(LogRapyutaCore,
+           Log,
+           TEXT("[ARRROS2GameMode] INIT GAME [%s/%s] - Options: %s\n%s!"),
+           *InMapName,
+           *GetWorld()->GetName(),
+           *InOptions,
+           *OutErrorMessage);
+    UE_LOG(LogRapyutaCore,
+           Log,
+           TEXT("NUM OF CPU CORES: [%d] - WITH HYPERTHREADS: [%d] - RECOMMENDED NUM OF WORKER THREADS: [%d]"),
+           FPlatformMisc::NumberOfCores(),
+           FPlatformMisc::NumberOfCoresIncludingHyperthreads(),
+           FPlatformMisc::NumberOfWorkerThreadsToSpawn());
+    UE_LOG(LogRapyutaCore, Display, TEXT("ShouldUseThreadingForPerformance: %d"), FApp::ShouldUseThreadingForPerformance());
+
+    // Init Sim main components
+    InitSim();
+}
+
+void ARRROS2GameMode::InitSim()
+{
+    InitROS2();
+}
+
+void ARRROS2GameMode::InitROS2()
+{
+    if (IsValid(ROS2Node))
+    {
+        return;
+    }
 
     UWorld* currentWorld = GetWorld();
     ROS2Node = currentWorld->SpawnActor<AROS2Node>();
@@ -27,6 +60,5 @@ void ARRROS2GameMode::BeginPlay()
 
     // Simulation state
     SimulationState = currentWorld->SpawnActor<ASimulationState>();
-    SimulationState->ROSServiceNode = ROS2Node;
-    SimulationState->Init();
+    SimulationState->Init(ROS2Node);
 }

--- a/Source/RapyutaSimulationPlugins/Private/RRROS2GameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/RRROS2GameMode.cpp
@@ -18,7 +18,7 @@ void ARRROS2GameMode::InitGame(const FString& InMapName, const FString& InOption
     Super::InitGame(InMapName, InOptions, OutErrorMessage);
     UE_LOG(LogRapyutaCore,
            Log,
-           TEXT("[ARRROS2GameMode] INIT GAME [%s/%s] - Options: %s\n%s!"),
+           TEXT("[ARRROS2GameMode] INIT GAME [%s/%s] - Options: %s\n%s"),
            *InMapName,
            *GetWorld()->GetName(),
            *InOptions,

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RobotVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RobotVehicle.cpp
@@ -8,26 +8,36 @@
 
 // RapyutaSimulationPlugins
 #include "Drives/RobotVehicleMovementComponent.h"
+#include "Robots/RRRobotVehicleROSController.h"
 #include "Tools/ROS2Spawnable.h"
 #include "Tools/SimulationState.h"
 
 ARobotVehicle::ARobotVehicle()
 {
-    Initialize();
+    SetupDefault();
 }
 
 ARobotVehicle::ARobotVehicle(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
 {
-    Initialize();
+    SetupDefault();
 }
 
-void ARobotVehicle::Initialize()
+void ARobotVehicle::SetupDefault()
 {
+    // Generally, for sake of dynamic robot type import/creation, child components would be then created on the fly!
+    // Besides, a default subobject, upon content changes, also makes the owning actor become vulnerable since one in child BP actor
+    // classes will automatically get invalidated.
+
+    // [SkeletalMeshComp], due to the support for being configured in certain [ARobotVehicle]'s BP classes,
+    // needs to be created in ctor.
+    // Reference: AWheeledVehiclePawn
     SkeletalMeshComp = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("SkeletalMeshComp"));
     SkeletalMeshComp->VisibilityBasedAnimTickOption = EVisibilityBasedAnimTickOption::AlwaysTickPose;
     SkeletalMeshComp->SetCollisionProfileName(UCollisionProfile::Pawn_ProfileName);
     AddOwnedComponent(SkeletalMeshComp);
     RootComponent = SkeletalMeshComp;
+
+    AIControllerClass = ARRRobotVehicleROSController::StaticClass();
 }
 
 bool ARobotVehicle::InitSensors(AROS2Node* InROS2Node)

--- a/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
@@ -22,8 +22,10 @@ ASimulationState::ASimulationState()
     PrimaryActorTick.bCanEverTick = true;
 }
 
-void ASimulationState::Init()
+void ASimulationState::Init(AROS2Node* InROS2Node)
 {
+    ROSServiceNode = InROS2Node;
+
     // register delegates to node
     FServiceCallback GetEntityStateSrvCallback;
     FServiceCallback SetEntityStateSrvCallback;
@@ -56,7 +58,6 @@ void ASimulationState::Init()
 
 void ASimulationState::AddEntity(AActor* Entity)
 {
-    // is GetName for editor only?
     Entities.Emplace(Entity->GetName(), Entity);
 }
 

--- a/Source/RapyutaSimulationPlugins/Public/RRROS2GameMode.h
+++ b/Source/RapyutaSimulationPlugins/Public/RRROS2GameMode.h
@@ -30,7 +30,10 @@ public:
     UPROPERTY(BlueprintReadWrite)
     FString UENodeName = TEXT("UENode");
 
-
 protected:
-    virtual void BeginPlay() override;
+    virtual void InitGame(const FString& InMapName, const FString& InOptions, FString& OutErrorMessage) override;
+    virtual void InitSim();
+
+private:
+    void InitROS2();
 };

--- a/Source/RapyutaSimulationPlugins/Public/RRROS2GameMode.h
+++ b/Source/RapyutaSimulationPlugins/Public/RRROS2GameMode.h
@@ -18,13 +18,13 @@ UCLASS() class RAPYUTASIMULATIONPLUGINS_API ARRROS2GameMode : public AGameMode
     GENERATED_BODY()
 
 public:
-    UPROPERTY(BlueprintReadWrite)
+    UPROPERTY(BlueprintReadOnly)
     AROS2Node* ROS2Node = nullptr;
 
-    UPROPERTY(BlueprintReadWrite)
+    UPROPERTY(BlueprintReadOnly)
     URRROS2ClockPublisher* ClockPublisher = nullptr;
 
-    UPROPERTY(BlueprintReadWrite)
+    UPROPERTY(BlueprintReadOnly)
     ASimulationState* SimulationState = nullptr;
 
     UPROPERTY(BlueprintReadWrite)

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RobotVehicle.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RobotVehicle.h
@@ -27,6 +27,11 @@ public:
     ARobotVehicle();
     ARobotVehicle(const FObjectInitializer& ObjectInitializer);
 
+    // Actually Object's Name is also unique as noted by UE, but we just do not want to rely on it.
+    // Instead, WE USE [RobotUniqueName] TO MAKE THE ROBOT ID CONTROL MORE INDPENDENT of UE INTERNAL NAME HANDLING.
+    // Reasons:
+    // + An Actor's Name could get updated as its Label is updated
+    // + In pending-kill state, GetName() goes to [None]
     UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ExposeOnSpawn = "true"))
     FString RobotUniqueName;
 
@@ -43,7 +48,7 @@ public:
     TSubclassOf<URobotVehicleMovementComponent> VehicleMoveComponentClass;
 
     bool InitSensors(AROS2Node* InROS2Node);
-    void Initialize();
+    void SetupDefault();
 
     UFUNCTION(BlueprintCallable)
     virtual void SetLinearVel(const FVector& InLinearVelocity);

--- a/Source/RapyutaSimulationPlugins/Public/Tools/SimulationState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Tools/SimulationState.h
@@ -52,7 +52,7 @@ public:
                                       FQuat& InOrientation);
 
     // need node that will handle services - this class will only define and register the service
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    UPROPERTY(BlueprintReadOnly)
     AROS2Node* ROSServiceNode = nullptr;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)

--- a/Source/RapyutaSimulationPlugins/Public/Tools/SimulationState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Tools/SimulationState.h
@@ -21,7 +21,7 @@ public:
 
 public:
     UFUNCTION(BlueprintCallable)
-    void Init();
+    void Init(AROS2Node* InROS2Node);
 
     UFUNCTION(BlueprintCallable)
     void GetEntityStateSrv(UROS2GenericSrv* Service);
@@ -53,7 +53,7 @@ public:
 
     // need node that will handle services - this class will only define and register the service
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    AROS2Node* ROSServiceNode;
+    AROS2Node* ROSServiceNode = nullptr;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     TMap<FString, AActor*> Entities;


### PR DESCRIPTION
- [x] RRROS2GameMode: Move ROS2 start to an earlier moment as in `InitGame()`, which runs before GameState, PC and thus all of its child actors, objects' BeginPlay()
https://rapyuta-robotics.slack.com/archives/C012TP5GKJ4/p1642133937053500?thread_ts=1640311193.370700&cid=C012TP5GKJ4