### PR TITLE
Fix base lidar topic name + FrameId

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RRBaseLidarComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RRBaseLidarComponent.cpp
@@ -8,6 +8,8 @@
 URRBaseLidarComponent::URRBaseLidarComponent()
 {
     BWithNoise = true;
+    TopicName = TEXT("scan");
+    FrameId = TEXT("base_scan");
 }
 
 void URRBaseLidarComponent::BeginPlay()

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2BaseSensorComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2BaseSensorComponent.cpp
@@ -27,6 +27,7 @@ void URRROS2BaseSensorComponent::CreatePublisher(const FString& InPublisherName)
     // Init [SensorPublisher] info
     if (nullptr == SensorPublisher)
     {
+        verify(SensorPublisherClass);
         FString PublisherName =
             InPublisherName.IsEmpty() ? FString::Printf(TEXT("%sSensorPublisher"), *GetName()) : InPublisherName;
         // Instantiate publisher

--- a/Source/RapyutaSimulationPlugins/Private/Tools/RRROS2ActorTFPublisher.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/RRROS2ActorTFPublisher.cpp
@@ -8,8 +8,8 @@ void URRROS2ActorTFPublisher::InitializeWithROS2(AROS2Node* InROS2Node)
 
     // register delegates to node
     FServiceCallback TriggerPublishSrvCallback;
-    TriggerPublishSrvCallback.BindUObject(this, &URRROS2ActorTFPublisher::TriggerPublishSrv);
-    InROS2Node->AddService(TriggerServiceName, UROS2SetBoolSrv::StaticClass(), TriggerPublishSrvCallback);
+    TriggerPublishSrvCallback.BindDynamic(this, &URRROS2ActorTFPublisher::TriggerPublishSrv);
+    InROS2Node->AddServiceServer(TriggerServiceName, UROS2SetBoolSrv::StaticClass(), TriggerPublishSrvCallback);
 }
 
 void URRROS2ActorTFPublisher::TriggerPublishSrv(UROS2GenericSrv* Service)

--- a/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
@@ -32,16 +32,16 @@ void ASimulationState::Init(AROS2Node* InROS2Node)
     FServiceCallback AttachSrvCallback;
     FServiceCallback SpawnEntitySrvCallback;
     FServiceCallback DeleteEntitySrvCallback;
-    GetEntityStateSrvCallback.BindUObject(this, &ASimulationState::GetEntityStateSrv);
-    SetEntityStateSrvCallback.BindUObject(this, &ASimulationState::SetEntityStateSrv);
-    AttachSrvCallback.BindUObject(this, &ASimulationState::AttachSrv);
-    SpawnEntitySrvCallback.BindUObject(this, &ASimulationState::SpawnEntitySrv);
-    DeleteEntitySrvCallback.BindUObject(this, &ASimulationState::DeleteEntitySrv);
-    ROSServiceNode->AddService(TEXT("GetEntityState"), UROS2GetEntityStateSrv::StaticClass(), GetEntityStateSrvCallback);
-    ROSServiceNode->AddService(TEXT("SetEntityState"), UROS2SetEntityStateSrv::StaticClass(), SetEntityStateSrvCallback);
-    ROSServiceNode->AddService(TEXT("Attach"), UROS2AttachSrv::StaticClass(), AttachSrvCallback);
-    ROSServiceNode->AddService(TEXT("SpawnEntity"), UROS2SpawnEntitySrv::StaticClass(), SpawnEntitySrvCallback);
-    ROSServiceNode->AddService(TEXT("DeleteEntity"), UROS2DeleteEntitySrv::StaticClass(), DeleteEntitySrvCallback);
+    GetEntityStateSrvCallback.BindDynamic(this, &ASimulationState::GetEntityStateSrv);
+    SetEntityStateSrvCallback.BindDynamic(this, &ASimulationState::SetEntityStateSrv);
+    AttachSrvCallback.BindDynamic(this, &ASimulationState::AttachSrv);
+    SpawnEntitySrvCallback.BindDynamic(this, &ASimulationState::SpawnEntitySrv);
+    DeleteEntitySrvCallback.BindDynamic(this, &ASimulationState::DeleteEntitySrv);
+    ROSServiceNode->AddServiceServer(TEXT("GetEntityState"), UROS2GetEntityStateSrv::StaticClass(), GetEntityStateSrvCallback);
+    ROSServiceNode->AddServiceServer(TEXT("SetEntityState"), UROS2SetEntityStateSrv::StaticClass(), SetEntityStateSrvCallback);
+    ROSServiceNode->AddServiceServer(TEXT("Attach"), UROS2AttachSrv::StaticClass(), AttachSrvCallback);
+    ROSServiceNode->AddServiceServer(TEXT("SpawnEntity"), UROS2SpawnEntitySrv::StaticClass(), SpawnEntitySrvCallback);
+    ROSServiceNode->AddServiceServer(TEXT("DeleteEntity"), UROS2DeleteEntitySrv::StaticClass(), DeleteEntitySrvCallback);
 
     // add all actors
 #if WITH_EDITOR


### PR DESCRIPTION
* `URRBaseLidarComponent : public URRROS2BaseSensorComponent` from #39
* URRBaseLidarComponent's TopicName & FrameId was [previously](https://github.com/rapyuta-robotics/RapyutaSimulationPlugins/blob/6587c499792d7dc6aa27620191a81dd35a3ff549/Source/RapyutaSimulationPlugins/Public/Sensors/RRBaseLidarComponent.h#L68) set as `scan` & `base_scan` respectively, of which now `TopicName` assign its value to `SensorPublisher's TopicName` in `URRROS2BaseSensorComponent::PreInitializePublisher()`
* Currently, `TopicName & FrameId` set as `sensor_data & sensor_frame` by default.

-> This PR specifies their values for `URRBaseLidarComponent`.