### PR TITLE
Skeletal robot custom utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog for RapyutaSimulationPlugins repository
 
+## 0.0.2 ##
+* Add core sources (`URRActorCommon, URRObjectCommon, ARRBaseActor, ARRMeshActor, ARRSceneDirector, URRStaticMeshComponent, ARRGameState, URRGameInstance, ARRPlayerController, ~Utils`)
+* `ARRRobotVehicle`: Add `InitMoveComponent()`, allowing `RobotVehicleMoveComponent` to be custom-initialized in child classes
+* `URRGameSingleton`: Add skeletal mesh related resource types (`USkeletalMesh, USkeleton, UPhysicsAsset`) & their fetching apis
+
 ## 0.0.1 ##
-------------------------
 * Add CHANGELOG
 * Update maintainers

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -11,7 +11,11 @@
 
 TMap<ERRResourceDataType, TArray<const TCHAR*>> URRGameSingleton::SASSET_OWNING_MODULE_NAMES = {
     {ERRResourceDataType::UE_STATIC_MESH, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
-    {ERRResourceDataType::UE_MATERIAL, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}}};
+    {ERRResourceDataType::UE_RUNTIME_MESH, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
+    {ERRResourceDataType::UE_SKELETAL_MESH, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
+    {ERRResourceDataType::UE_SKELETON, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
+    {ERRResourceDataType::UE_PHYSICS_ASSET, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
+};
 
 URRGameSingleton::URRGameSingleton(){
     UE_LOG(LogRapyutaCore, Display, TEXT("[RR GAME SINGLETON] INSTANTIATED! ======================"))}
@@ -69,9 +73,19 @@ bool URRGameSingleton::InitializeResources()
     GetSimResourceInfo(dataType).HasBeenAllLoaded = false;
     verify(RequestResourcesLoading(dataType));
 
+    // (NOTE) RuntimeMesh & SkeletalMesh-related resources are only created in runtime for now
+    // (though they could be also loaded from Content)
     // [RUNTIME MESH] --
-    // (NOTE) These resources are dynamically loaded at run-time
     GetSimResourceInfo(ERRResourceDataType::UE_RUNTIME_MESH).HasBeenAllLoaded = true;
+
+    // [SKELETAL MESH] --
+    GetSimResourceInfo(ERRResourceDataType::UE_SKELETAL_MESH).HasBeenAllLoaded = true;
+
+    // [SKELETON] --
+    GetSimResourceInfo(ERRResourceDataType::UE_SKELETON).HasBeenAllLoaded = true;
+
+    // [PHYSICS ASSET] --
+    GetSimResourceInfo(ERRResourceDataType::UE_PHYSICS_ASSET).HasBeenAllLoaded = true;
 
     // [MATERIAL] --
     dataType = ERRResourceDataType::UE_MATERIAL;

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RobotVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RobotVehicle.cpp
@@ -88,7 +88,6 @@ bool ARobotVehicle::InitMoveComponent()
 
 void ARobotVehicle::SetLinearVel(const FVector& InLinearVelocity)
 {
-    // We're assuming input is in meters, so convert to centimeters.
     RobotVehicleMoveComponent->Velocity = InLinearVelocity;
 }
 

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RobotVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RobotVehicle.cpp
@@ -59,20 +59,8 @@ bool ARobotVehicle::InitSensors(AROS2Node* InROS2Node)
     return true;
 }
 
-void ARobotVehicle::SetLinearVel(const FVector& InLinearVelocity)
+bool ARobotVehicle::InitMoveComponent()
 {
-    // We're assuming input is in meters, so convert to centimeters.
-    RobotVehicleMoveComponent->Velocity = InLinearVelocity;
-}
-
-void ARobotVehicle::SetAngularVel(const FVector& InAngularVelocity)
-{
-    RobotVehicleMoveComponent->AngularVelocity = InAngularVelocity;
-}
-
-void ARobotVehicle::PostInitializeComponents()
-{
-    Super::PostInitializeComponents();
     if (VehicleMoveComponentClass)
     {
         // (NOTE) Being created in [OnConstruction], PIE will cause this to be reset anyway, thus requires recreation
@@ -88,10 +76,29 @@ void ARobotVehicle::PostInitializeComponents()
 
         // (NOTE) With [bAutoRegisterUpdatedComponent] as true by default, UpdatedComponent component will be automatically set
         // to the owner actor's root
+        return true;
     }
     else
     {
         // [OnConstruction] could run in various Editor BP actions, thus could not do Fatal log here
         UE_LOG(LogRapyutaCore, Warning, TEXT("[%s] [VehicleMoveComponentClass] has not been configured!"), *GetName());
+        return false;
     }
+}
+
+void ARobotVehicle::SetLinearVel(const FVector& InLinearVelocity)
+{
+    // We're assuming input is in meters, so convert to centimeters.
+    RobotVehicleMoveComponent->Velocity = InLinearVelocity;
+}
+
+void ARobotVehicle::SetAngularVel(const FVector& InAngularVelocity)
+{
+    RobotVehicleMoveComponent->AngularVelocity = InAngularVelocity;
+}
+
+void ARobotVehicle::PostInitializeComponents()
+{
+    Super::PostInitializeComponents();
+    InitMoveComponent();
 }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -4,6 +4,7 @@
 #include "CoreMinimal.h"
 
 // UE
+#include "Engine/SkeletalMesh.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/StreamableManager.h"
 #include "Materials/Material.h"
@@ -249,6 +250,22 @@ public:
     FORCEINLINE UStaticMesh* GetStaticMesh(const FString& InStaticMeshName)
     {
         return GetSimResource<UStaticMesh>(ERRResourceDataType::UE_STATIC_MESH, InStaticMeshName);
+    }
+
+    // SKELETAL ASSETS --
+    FORCEINLINE USkeletalMesh* GetSkeletalMesh(const FString& InSkeletalMeshName)
+    {
+        return GetSimResource<USkeletalMesh>(ERRResourceDataType::UE_SKELETAL_MESH, InSkeletalMeshName);
+    }
+
+    FORCEINLINE USkeleton* GetSkeleton(const FString& InSkeletonName)
+    {
+        return GetSimResource<USkeleton>(ERRResourceDataType::UE_SKELETON, InSkeletonName);
+    }
+
+    FORCEINLINE UPhysicsAsset* GetPhysicsAsset(const FString& InPhysicsAssetName)
+    {
+        return GetSimResource<UPhysicsAsset>(ERRResourceDataType::UE_PHYSICS_ASSET, InPhysicsAssetName);
     }
 
     // MATERIALS --

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
@@ -21,6 +21,9 @@ enum class ERRResourceDataType : uint8
     // UASSET --
     UE_STATIC_MESH,
     UE_RUNTIME_MESH,
+    UE_SKELETAL_MESH,
+    UE_SKELETON,
+    UE_PHYSICS_ASSET,
     UE_MATERIAL,
 
     TOTAL

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RobotVehicle.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RobotVehicle.h
@@ -49,6 +49,7 @@ public:
     TSubclassOf<URobotVehicleMovementComponent> VehicleMoveComponentClass;
 
     bool InitSensors(AROS2Node* InROS2Node);
+    virtual bool InitMoveComponent();
     void SetupDefault();
 
     UFUNCTION(BlueprintCallable)

--- a/Source/RapyutaSimulationPlugins/Public/Sensors/RRBaseLidarComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Sensors/RRBaseLidarComponent.h
@@ -29,7 +29,6 @@ protected:
     virtual void BeginPlay() override;
 
 public:
-
     UFUNCTION(BlueprintCallable)
     virtual bool Visible(AActor* TargetActor)
     {
@@ -79,6 +78,21 @@ public:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
     float DHAngle = 0.f;
 
+    UPROPERTY(EditAnywhere, Category = "Noise")
+    float PositionalNoiseMean = 0.f;
+
+    UPROPERTY(EditAnywhere, Category = "Noise")
+    float PositionalNoiseVariance = 1.f;
+
+    UPROPERTY(EditAnywhere, Category = "Noise")
+    float IntensityNoiseMean = 0.f;
+
+    UPROPERTY(EditAnywhere, Category = "Noise")
+    float IntensityNoiseVariance = .1f;
+
+    UPROPERTY(EditAnywhere, Category = "Noise")
+    uint8 BWithNoise : 1;
+
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
     TArray<FHitResult> RecordedHits;
 
@@ -115,21 +129,6 @@ protected:
     std::mt19937 Gen = std::mt19937{Rng()};
     std::normal_distribution<> GaussianRNGPosition;
     std::normal_distribution<> GaussianRNGIntensity;
-
-    UPROPERTY(EditAnywhere, Category = "Noise")
-    float PositionalNoiseMean = 0.f;
-
-    UPROPERTY(EditAnywhere, Category = "Noise")
-    float PositionalNoiseVariance = 1.f;
-
-    UPROPERTY(EditAnywhere, Category = "Noise")
-    float IntensityNoiseMean = 0.f;
-
-    UPROPERTY(EditAnywhere, Category = "Noise")
-    float IntensityNoiseVariance = .1f;
-
-    UPROPERTY(EditAnywhere, Category = "Noise")
-    uint8 BWithNoise : 1;
 
     FLinearColor InterpolateColor(float InX);
     static float GetIntensityFromDist(float InBaseIntensity, float InDistance);


### PR DESCRIPTION
[Turtlebot3-UE's SkeletalRobotImporter](https://github.com/rapyuta-robotics/turtlebot3-UE/tree/SkeletalRobotImporter)
* `ARRRobotVehicle` requires its `MoveComponent` to be initialized in `PostInitializeComponents()`, either as a kinematics-only `URobotVehicleMovementComponent` or physically diff-drive `UDifferentialDriveComponent`, depending on `VehicleMoveComponentClass`, which has been so-far must be non-nullptr in ctor (as configured in BP or in `ATurtlebotBurger`).

* With the dynamic creation of skeletal robot, which instantiates its `MoveComponent` based on info specified in `urdf/sdf`, `VehicleMoveComponentClass` could only be inevitably initialized after `ctor`, and thus it requires a standalone method of `MoveComponent` creation accordingly to be invoked independently outside of `PostInitializeComponents`.
-> Thus comes the added virtual `InitMoveComponent()`

* `URRGameSingleton`: Add skeletal mesh-related resource types (`USkeletalMesh, USkeleton, UPhysicsAsset`) & their fetching apis, for enabling those assets to be reusable in case of multi spawned robots.
* `RRBaseLidarComponent.h`: Enable access to noise properties that could be initialized from info in sdf.