### PR TITLE
reset the array ContactPoints

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
@@ -296,6 +296,7 @@ void URobotVehicleMovementComponent::InitMovementComponent()
 {
     InitOdom();
 
+    ContactPoints.Empty();
     TArray<UActorComponent*> actorContactPoints = PawnOwner->GetComponentsByTag(USceneComponent::StaticClass(), "ContactPoint");
     for (auto acp : actorContactPoints)
     {


### PR DESCRIPTION
Needed to correct motion on ramps if the function InitMovementComponent is called many times (can be called in Blueprint side too).
For example, InitMovementComponent() may be called to reset the robot state in the environment because robot state or environment state have changed (robot teleportation, spawn of obstacles..)