### PR TITLE
Collision fix2

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
@@ -302,7 +302,7 @@ void URobotVehicleMovementComponent::InitMovementComponent()
         USceneComponent* scp = Cast<USceneComponent>(acp);
         ContactPoints.Add(scp);
     }
-    UE_LOG(LogTemp,
+    UE_LOG(LogRapyutaCore,
            Warning,
            TEXT("URobotVehicleMovementComponent::InitMovementComponent - Nb Contact Points : %d"),
            ContactPoints.Num());
@@ -328,7 +328,7 @@ void URobotVehicleMovementComponent::InitMovementComponent()
     {
         MinDistanceToFloor = hitResult.Distance;
     }
-    UE_LOG(LogTemp,
+    UE_LOG(LogRapyutaCore,
            Warning,
            TEXT("URobotVehicleMovementComponent::InitMovementComponent - Min Distance To Floor = %f"),
            MinDistanceToFloor);

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
@@ -221,11 +221,14 @@ void ARRRobotVehicleROSController::JointStateCallback(const UROS2GenericMsg* Msg
         {
             if (!vehicle->Joints.Contains(jointState.name[i]))
             {
-                UE_LOG(LogTemp,
-                       Warning,
-                       TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] vehicle do not have joint named %s."),
-                       *GetName(),
-                       *jointState.name[i]);
+                if (bWarnAboutMissingLink)
+                {
+                    UE_LOG(LogTemp,
+                        Warning,
+                        TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] vehicle do not have joint named %s."),
+                        *GetName(),
+                        *jointState.name[i]);
+                }
                 continue;
             }
 

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
@@ -101,7 +101,7 @@ void ARRRobotVehicleROSController::SubscribeToMovementCommandTopic(const FString
     if (InTopicName.IsEmpty())
     {
         UE_LOG(
-            LogTemp,
+            LogRapyutaCore,
             Warning,
             TEXT(
                 "[%s] [RRRobotVehicleROSController] [SubscribeToMovementCommandTopic] TopicName is empty. Do not subscribe topic."),
@@ -114,7 +114,7 @@ void ARRRobotVehicleROSController::SubscribeToMovementCommandTopic(const FString
     {
         FSubscriptionCallback cb;
         cb.BindDynamic(this, &ARRRobotVehicleROSController::MovementCallback);
-        UE_LOG(LogTemp,
+        UE_LOG(LogRapyutaCore,
                Warning,
                TEXT("[RRRobotVehicleROSController] [SubscribeToMovementCommandTopic] TopicName  = %s"),
                *InTopicName);
@@ -155,7 +155,7 @@ void ARRRobotVehicleROSController::SubscribeToJointsCommandTopic(const FString& 
     if (InTopicName.IsEmpty())
     {
         UE_LOG(
-            LogTemp,
+            LogRapyutaCore,
             Warning,
             TEXT(
                 "[%s] [RRRobotVehicleROSController] [SubscribeToMovementCommandTopic] TopicName is empty. Do not subscribe topic."),
@@ -197,7 +197,7 @@ void ARRRobotVehicleROSController::JointStateCallback(const UROS2GenericMsg* Msg
         else if (jointState.name.Num() == jointState.effort.Num())
         {
             jointControlType = EJointControlType::EFFORT;
-            UE_LOG(LogTemp,
+            UE_LOG(LogRapyutaCore,
                    Warning,
                    TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] Effort control is not supported."),
                    *GetName());
@@ -205,7 +205,7 @@ void ARRRobotVehicleROSController::JointStateCallback(const UROS2GenericMsg* Msg
         }
         else
         {
-            UE_LOG(LogTemp,
+            UE_LOG(LogRapyutaCore,
                    Warning,
                    TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] position, velocity or effort array must be same "
                         "size of name array"),
@@ -221,7 +221,7 @@ void ARRRobotVehicleROSController::JointStateCallback(const UROS2GenericMsg* Msg
             {
                 if (bWarnAboutMissingLink)
                 {
-                    UE_LOG(LogTemp,
+                    UE_LOG(LogRapyutaCore,
                            Warning,
                            TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] vehicle do not have joint named %s."),
                            *GetName(),
@@ -242,7 +242,7 @@ void ARRRobotVehicleROSController::JointStateCallback(const UROS2GenericMsg* Msg
             else
             {
                 UE_LOG(
-                    LogTemp,
+                    LogRapyutaCore,
                     Warning,
                     TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] position, velocity or effort array must be same "
                          "size of name array"),
@@ -261,7 +261,7 @@ void ARRRobotVehicleROSController::JointStateCallback(const UROS2GenericMsg* Msg
             }
             else
             {
-                UE_LOG(LogTemp,
+                UE_LOG(LogRapyutaCore,
                        Warning,
                        TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] Supports only single DOF joint. %s has %d "
                             "linear DOF and %d rotational DOF"),

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
@@ -114,12 +114,10 @@ void ARRRobotVehicleROSController::SubscribeToMovementCommandTopic(const FString
     {
         FSubscriptionCallback cb;
         cb.BindDynamic(this, &ARRRobotVehicleROSController::MovementCallback);
-        UE_LOG(
-            LogTemp,
-            Warning,
-            TEXT(
-                "[RRRobotVehicleROSController] [SubscribeToMovementCommandTopic] TopicName  = %s"),
-            *InTopicName );
+        UE_LOG(LogTemp,
+               Warning,
+               TEXT("[RRRobotVehicleROSController] [SubscribeToMovementCommandTopic] TopicName  = %s"),
+               *InTopicName);
         RobotROS2Node->AddSubscription(InTopicName, UROS2TwistMsg::StaticClass(), cb);
     }
 }
@@ -224,10 +222,10 @@ void ARRRobotVehicleROSController::JointStateCallback(const UROS2GenericMsg* Msg
                 if (bWarnAboutMissingLink)
                 {
                     UE_LOG(LogTemp,
-                        Warning,
-                        TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] vehicle do not have joint named %s."),
-                        *GetName(),
-                        *jointState.name[i]);
+                           Warning,
+                           TEXT("[%s] [RRRobotVehicleROSController] [JointStateCallback] vehicle do not have joint named %s."),
+                           *GetName(),
+                           *jointState.name[i]);
                 }
                 continue;
             }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RobotBaseVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RobotBaseVehicle.cpp
@@ -123,7 +123,7 @@ void ARobotBaseVehicle::SetJointState(const TMap<FString, TArray<float>>& InJoin
         }
         else
         {
-            UE_LOG(LogTemp,
+            UE_LOG(LogRapyutaCore,
                    Warning,
                    TEXT("[%s] [RobotBaseVehicle] [SetJointState] do not have joint named %s "),
                    *GetName(),

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RobotBaseVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RobotBaseVehicle.cpp
@@ -28,10 +28,17 @@ void ARobotBaseVehicle::SetupDefault()
     // Besides, a default subobject, upon content changes, also makes the owning actor become vulnerable since one in child BP actor
     // classes will automatically get invalidated.
 
-    RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("SceneComp"));
+    RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
 
     AIControllerClass = ARRRobotVehicleROSController::StaticClass();
     AutoPossessAI = EAutoPossessAI::PlacedInWorldOrSpawned;
+}
+
+void ARobotBaseVehicle::SetRootOffset(const FTransform& InRootOffset)
+{
+    if( RobotVehicleMoveComponent == nullptr ) return;
+    
+    RobotVehicleMoveComponent->RootOffset = InRootOffset;
 }
 
 bool ARobotBaseVehicle::InitSensors(AROS2Node* InROS2Node)

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RobotBaseVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RobotBaseVehicle.cpp
@@ -36,8 +36,9 @@ void ARobotBaseVehicle::SetupDefault()
 
 void ARobotBaseVehicle::SetRootOffset(const FTransform& InRootOffset)
 {
-    if( RobotVehicleMoveComponent == nullptr ) return;
-    
+    if (RobotVehicleMoveComponent == nullptr)
+        return;
+
     RobotVehicleMoveComponent->RootOffset = InRootOffset;
 }
 
@@ -122,8 +123,11 @@ void ARobotBaseVehicle::SetJointState(const TMap<FString, TArray<float>>& InJoin
         }
         else
         {
-            UE_LOG(
-                LogTemp, Warning, TEXT("[%s] [RobotBaseVehicle] [SetJointState] do not have joint named %s "), *GetName(), *joint.Key);
+            UE_LOG(LogTemp,
+                   Warning,
+                   TEXT("[%s] [RobotBaseVehicle] [SetJointState] do not have joint named %s "),
+                   *GetName(),
+                   *joint.Key);
         }
     }
 }

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2EntityStateSensorComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2EntityStateSensorComponent.cpp
@@ -48,10 +48,10 @@ void URRROS2EntityStateSensorComponent::SensorUpdate()
 
     relativeTransf = URRConversionUtils::TransformUEToROS(relativeTransf);
 
-    Data.pose_position_x = relativeTransf.GetTranslation().X;
-    Data.pose_position_y = relativeTransf.GetTranslation().Y;
-    Data.pose_position_z = relativeTransf.GetTranslation().Z;
-    Data.pose_orientation = relativeTransf.GetRotation();
+    Data.pose_position_x = relativeTransf.GetTranslation().X + RootOffset.GetTranslation().X;
+    Data.pose_position_y = relativeTransf.GetTranslation().Y + RootOffset.GetTranslation().Y;
+    Data.pose_position_z = relativeTransf.GetTranslation().Z + RootOffset.GetTranslation().Z;
+    Data.pose_orientation = relativeTransf.GetRotation() * RootOffset.GetRotation();
     Data.reference_frame = ReferenceActorName;
 
     // todo calc vel

--- a/Source/RapyutaSimulationPlugins/Public/Drives/RobotVehicleMovementComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/RobotVehicleMovementComponent.h
@@ -32,17 +32,18 @@ enum class EOdomSource : uint8
 };
 
 /**
- * @brief Base Robot vehicle movement class which is used as part of #ARobotVehicle. 
+ * @brief Base Robot vehicle movement class which is used as part of #ARobotVehicle.
  * Robot moves based on the Velocity(member of UMovementComponent) and #AngularVelocity without considering physics.
  * If Robot bumped into something, try to slide along it.
- * 
- * If #bAdaptToSurfaceBelow is true, robot will follow the pawn movement under the robot which has been defined as the #MovingPlatform (e.g. elevators), it will also adapt its pose to the floor surface configuration (e.g. slopes)
+ *
+ * If #bAdaptToSurfaceBelow is true, robot will follow the pawn movement under the robot which has been defined as the
+ #MovingPlatform (e.g. elevators), it will also adapt its pose to the floor surface configuration (e.g. slopes)
 
- * 
+ *
  * Publish odometry from world origin or initial pose.
  *
  * @sa [UPawnMovementComponent](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UPawnMovementComponent/)
- * 
+ *
  * @todo Support 3D movement.
  * @todo Expose odom covariance parameter.
  */
@@ -56,7 +57,7 @@ private:
 
     //! The platform below the robot, e.g. elevator.
     UPROPERTY(VisibleAnywhere)
-    AActor* MovingPlatform = nullptr;    
+    AActor* MovingPlatform = nullptr;
 
     UPROPERTY(VisibleAnywhere)
     FVector LastPlatformLocation = FVector::ZeroVector;
@@ -64,17 +65,19 @@ private:
     UPROPERTY(VisibleAnywhere)
     FQuat LastPlatformRotation = FQuat::Identity;
 
-    //! List all scene components on the pawn. that have the tag "ContactPoint". This is used to adapt the robot pose based on the floor surface configuration.
+    //! List all scene components on the pawn. that have the tag "ContactPoint". This is used to adapt the robot pose based on the
+    //! floor surface configuration.
 
     UPROPERTY(VisibleAnywhere)
-    TArray<USceneComponent*> ContactPoints;    
+    TArray<USceneComponent*> ContactPoints;
 
 public:
     UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = Velocity)
     FVector AngularVelocity = FVector::ZeroVector;
- 
+
     //! Desired position calculated from deltatime and UpdatedComponent::ComponentVelocity
-    //! @sa [UpdatedComponent](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/UpdatedComponent/)
+    //! @sa
+    //! [UpdatedComponent](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/UpdatedComponent/)
     UPROPERTY(Transient)
     FVector DesiredMovement = FVector::ZeroVector;
 
@@ -95,9 +98,9 @@ public:
 
     /**
      * @brief Set the Frame Id and child frame id of odometry
-     * 
-     * @param InFrameId 
-     * @param InChildFrameId 
+     *
+     * @param InFrameId
+     * @param InChildFrameId
      */
     void SetFrameIds(const FString& InFrameId, const FString& InChildFrameId);
 
@@ -109,7 +112,7 @@ public:
     //! Ray start Z offset. Value must be > possible penetration of objects in contact point, in one tick
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     float RayOffsetUp = 10.f;
-    
+
     //! Ray end Z offset.
     //! Rays go from ContactPoint+RayOffsetUp to ContactPoint-RayOffsetDown
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
@@ -117,14 +120,14 @@ public:
 
     //! to activate/deactivate floor checks to stick the robot on its surface below
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    bool bAdaptToSurfaceBelow = true;   
+    bool bAdaptToSurfaceBelow = true;
 
     UFUNCTION(BlueprintCallable)
     FTransform GetOdomTF() const;
 
     /**
      * @brief Initialize noise and odometry.
-     * 
+     *
      */
     UFUNCTION(BlueprintCallable)
     virtual void Initialize();
@@ -142,7 +145,7 @@ public:
     /**
      * @brief Call #InitOdom, Calculate #MinDistanceToFloor, and
      * Add all actors in PawnOwner which has tag "ContactPoints" to #ContactPoints
-     * 
+     *
      */
     UFUNCTION(BlueprintCallable)
     virtual void InitMovementComponent();
@@ -160,35 +163,37 @@ public:
 
     //! [cm] Z distance between the robot root location and the floor, used when less than 3 contact points are defined
     UPROPERTY(VisibleAnywhere)
-    float MinDistanceToFloor = 0.f;   
+    float MinDistanceToFloor = 0.f;
 
     //![cm/s] How much the robot falls if no floor beneath ( FallingSpeed * DeltaTime )
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    float FallingSpeed = 100.f;    
+    float FallingSpeed = 100.f;
 
 protected:
-    
     virtual void BeginPlay() override;
-    
+
     /**
      * @brief Move actor by using SafeMoveUpdatedComponent and SlideAlongSurface.
      * Calculate #DesiredMovement and #DesiredRotation from deltatime, UpdatedComponent and #AngularVelocity.
-     * 
+     *
      * If #bAdaptToSurfaceBelow is true, robot will follow the pawn movement under the robot with tag "ContactPoints".
      * Please check the .cpp file for detailed implementation to follow platform.
-     * 
      *
-     * @param InDeltaTime 
-     * @sa [SafeMoveUpdatedComponent](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/SafeMoveUpdatedComponent/1/)
-     * @sa [SlideAlongSurface](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/SlideAlongSurface/)
-     * @sa [UpdatedComponent](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/UpdatedComponent/)
+     *
+     * @param InDeltaTime
+     * @sa
+     * [SafeMoveUpdatedComponent](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/SafeMoveUpdatedComponent/1/)
+     * @sa
+     * [SlideAlongSurface](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/SlideAlongSurface/)
+     * @sa
+     * [UpdatedComponent](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/UpdatedComponent/)
      */
     virtual void UpdateMovement(float InDeltaTime);
 
     /**
      * @brief Update odom.
      * Noise is integral of gaussian noise.
-     * @param InDeltaTime 
+     * @param InDeltaTime
      */
     virtual void UpdateOdom(float InDeltaTime);
 
@@ -202,7 +207,7 @@ protected:
 
     //! C++11 RNG for odometry noise
     std::mt19937 Gen = std::mt19937{Rng()};
-    
+
     std::normal_distribution<> GaussianRNGPosition;
     std::normal_distribution<> GaussianRNGRotation;
 
@@ -225,12 +230,13 @@ protected:
 public:
     /**
      * @brief Call #UpdateMovement, #UpdateOdom, and UpdateComponentVelocity
-     * 
-     * @param DeltaTime 
-     * @param TickType 
-     * @param ThisTickFunction 
      *
-     * @sa [UpdateComponentVelocity](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/UpdateComponentVelocity/)
+     * @param DeltaTime
+     * @param TickType
+     * @param ThisTickFunction
+     *
+     * @sa
+     * [UpdateComponentVelocity](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/UMovementComponent/UpdateComponentVelocity/)
      */
     virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 };

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotVehicleROSController.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotVehicleROSController.h
@@ -35,6 +35,10 @@ class RAPYUTASIMULATIONPLUGINS_API ARRRobotVehicleROSController : public AAICont
 {
     GENERATED_BODY()
 
+public:
+    UPROPERTY(BlueprintReadWrite)
+    bool bWarnAboutMissingLink = true;
+
 protected:
     UPROPERTY(Transient)
     AROS2Node* RobotROS2Node = nullptr;

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotVehicleROSController.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotVehicleROSController.h
@@ -119,10 +119,9 @@ protected:
 
     //! Movement command topic. If empty is given, subscriber will not be initiated.
     UPROPERTY(BlueprintReadWrite)
-	FString CmdVelTopicName = TEXT("cmd_vel");
+    FString CmdVelTopicName = TEXT("cmd_vel");
 
     //! Joint control command topic. If empty is given, subscriber will not be initiated.
-	UPROPERTY(BlueprintReadWrite)
-	FString JointsCmdTopicName = TEXT("joint_states");
-
+    UPROPERTY(BlueprintReadWrite)
+    FString JointsCmdTopicName = TEXT("joint_states");
 };

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RobotBaseVehicle.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RobotBaseVehicle.h
@@ -107,6 +107,16 @@ public:
     void SetupDefault();
 
     /**
+     * @brief Set the root offset for #RobotVehicleMoveComponent
+     * This will be added to the odometry data published in ros topic /odom 
+     * It is used, for example, to allow the robot root pose to remain constant even if we move the skeletal mesh root component for collisions
+     *
+     * @param InRootOffset
+     */
+    UFUNCTION(BlueprintCallable)
+    virtual void SetRootOffset(const FTransform& InRootOffset);
+
+    /**
      * @brief Set velocity to #RobotVehicleMoveComponent
      *
      * @param InLinearVelocity

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RobotBaseVehicle.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RobotBaseVehicle.h
@@ -108,8 +108,9 @@ public:
 
     /**
      * @brief Set the root offset for #RobotVehicleMoveComponent
-     * This will be added to the odometry data published in ros topic /odom 
-     * It is used, for example, to allow the robot root pose to remain constant even if we move the skeletal mesh root component for collisions
+     * This will be added to the odometry data published in ros topic /odom
+     * It is used, for example, to allow the robot root pose to remain constant even if we move the skeletal mesh root component for
+     * collisions
      *
      * @param InRootOffset
      */

--- a/Source/RapyutaSimulationPlugins/Public/Sensors/RRROS2EntityStateSensorComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Sensors/RRROS2EntityStateSensorComponent.h
@@ -1,6 +1,6 @@
 /**
  * @file RRROS2EntityStateSensorComponent.h
- * @brief EntityState sensor components which publish entitystate relative to a specific actor. 
+ * @brief EntityState sensor components which publish entitystate relative to a specific actor.
  * @copyright Copyright 2020-2022 Rapyuta Robotics Co., Ltd.
  */
 
@@ -22,7 +22,7 @@
 #include "RRROS2EntityStateSensorComponent.generated.h"
 
 /**
- * @brief EntityState sensor components which publish entitystate relative to a specific actor. 
+ * @brief EntityState sensor components which publish entitystate relative to a specific actor.
  * @todo Currently twist = ZeroVectors. Should be filled for physics actors.
  */
 UCLASS(ClassGroup = (Custom), Blueprintable, meta = (BlueprintSpawnableComponent))
@@ -33,7 +33,7 @@ class RAPYUTASIMULATIONPLUGINS_API URRROS2EntityStateSensorComponent : public UR
 public:
     /**
      * @brief Construct a new URRROS2EntityStateSensorComponent object
-     * 
+     *
      */
     URRROS2EntityStateSensorComponent();
 
@@ -55,24 +55,31 @@ public:
     virtual void SetReferenceActorByName(const FString& InName);
 
     UFUNCTION(BlueprintCallable)
+    virtual void SetRootOffset(const FTransform& InRootOffset);
+
+    UFUNCTION(BlueprintCallable)
     virtual void SetReferenceActorByActor(AActor* InActor);
 
     // ROS
     /**
      * @brief return #Data
-     * 
-     * @return FROSEntityState 
+     *
+     * @return FROSEntityState
      */
     UFUNCTION(BlueprintCallable)
     virtual FROSEntityState GetROS2Data();
 
     /**
      * @brief Set result of #GetROS2Data to InMessage.
-     * 
-     * @param InMessage 
+     *
+     * @param InMessage
      */
     virtual void SetROS2Msg(UROS2GenericMsg* InMessage) override;
 
     UPROPERTY(BlueprintReadWrite)
     FROSEntityState Data;
+
+private:
+    UPROPERTY()
+    FTransform RootOffset = FTransform::Identity;
 };


### PR DESCRIPTION
1) Only the root component of the robot BP is used to handle collisions.
When a robot uses a moving part that can collide with environment objects, we may need to keep the robot reference pose immobile while the skeletal mesh moves.
For such cases, I added 2 RootOffset variables, one for /odom and one for /ue_ros/model_state, that can be modified to correct the reference pose of the robot to compensate for the skeletal mesh local motion.

2) adding a variable to ignore warnings when some links are not available