### PR TITLE
ARRBaseRobot Add CreateRobotROS2Interface()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for RapyutaSimulationPlugins repository
 
+## 0.0.10 ##
+* `ARRBaseRobot` add ROS2Interface member & CreateRobotROS2Interface(), only instantiating it upon valid ROS2InterfaceClass
+* `ARRRobotVehicleROSController`: ARobotVehicle -> ARRRobotBaseVehicle
+* Add `ARRCrowAIController` since `ADetourCrowdAIController` lacks module API tag, thus is not compilable in EDITOR build
+* Add Scripts/verify_ue4_env.sh, so users could use a common custom env var (as path to UE4Editor) for all running scripts in client project repos
+* `URRRobotROS2Interface` Add `OnMessageReceived()`, being usable as a generic class callback
+
 ## 0.0.9 ##
 * `SimulationState` Add `SpawnEntity()`, used by `SpawnEntitySrv + SpawnEntitiesSrv`
 

--- a/Scripts/verify_ue4_env.sh
+++ b/Scripts/verify_ue4_env.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -z "${UE4}" ]; then
+	printf "Please set UE4 to path of UnrealEngine's parent folder\n"
+	exit 1
+fi
+exit 0

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCrowdAIController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCrowdAIController.cpp
@@ -1,0 +1,10 @@
+// Copyright 2020-2022 Rapyuta Robotics Co., Ltd.
+#include "Core/RRCrowdAIController.h"
+
+// UE
+#include "Navigation/CrowdFollowingComponent.h"
+
+ARRCrowdAIController::ARRCrowdAIController(const FObjectInitializer& ObjectInitializer)
+    : Super(ObjectInitializer.SetDefaultSubobjectClass<UCrowdFollowingComponent>(TEXT("PathFollowingComponent")))
+{
+}

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
@@ -27,6 +27,7 @@ URRProceduralMeshComponent::URRProceduralMeshComponent(const FObjectInitializer&
     // Thus we could only rely on [UBodySetup::bCreatedPhysicsMeshes]
     bUseAsyncCooking = true;
     bUseComplexAsSimpleCollision = false;
+    bCanEverAffectNavigation = true;
 
     OnMeshCreationDone.BindUObject(Cast<ARRMeshActor>(GetOwner()), &ARRMeshActor::OnBodyComponentMeshCreationDone);
 }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -7,6 +7,7 @@
 #include "ROS2Node.h"
 
 // RapyutaSimulationPlugins
+#include "Core/RRUObjectUtils.h"
 #include "Drives/RRJointComponent.h"
 #include "Robots/RRRobotROS2Interface.h"
 #include "Sensors/RRROS2BaseSensorComponent.h"
@@ -28,9 +29,37 @@ void ARRBaseRobot::SetupDefault()
     // Generally, for sake of dynamic robot type import/creation, child components would be then created on the fly!
     // Besides, a default subobject, upon content changes, also makes the owning actor become vulnerable since one in child BP actor
     // classes will automatically get invalidated.
+    URRUObjectUtils::SetupDefaultRootComponent(this);
 
-    RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
-    ROS2InterfaceClass = URRRobotROS2Interface::StaticClass();
+    // NOTE: Any custom object class (eg ROS2InterfaceClass) that is required to be configurable by this class' child BP ones
+    // & IF its object needs to be created before BeginPlay(),
+    // -> They must be left NULL here, so its object (eg ROS2Interface) is not created by default in [PostInitializeComponents()]
+}
+
+void ARRBaseRobot::PostInitializeComponents()
+{
+    Super::PostInitializeComponents();
+    if (ROS2InterfaceClass)
+    {
+        CreateROS2Interface();
+    }
+    else
+    {
+        // [OnConstruction] could run in various Editor BP actions, thus could not do Fatal log here
+        UE_LOG(LogRapyutaCore,
+               Warning,
+               TEXT("[%s] [ARRBaseRobot::PostInitializeComponents()] ROS2InterfaceClass has not been configured, "
+                    "probably later in child BP class!"),
+               *GetName());
+    }
+}
+
+void ARRBaseRobot::CreateROS2Interface()
+{
+    ROS2Interface = CastChecked<URRRobotROS2Interface>(
+        URRUObjectUtils::CreateSelfSubobject(this, ROS2InterfaceClass, FString::Printf(TEXT("%sROS2Interface"), *GetName())));
+    // NOTE: NOT call ROS2Interface->Initialize(this) here since robot's ros2-based accessories might not have been fully accessible
+    // yet. For sure, that would be done in Controller's OnPossess
 }
 
 bool ARRBaseRobot::InitSensors(AROS2Node* InROS2Node)
@@ -40,8 +69,10 @@ bool ARRBaseRobot::InitSensors(AROS2Node* InROS2Node)
         return false;
     }
 
-    // (NOTE) Use [ForEachComponent] would cause a fatal log on
-    // [Container has changed during ranged-for iteration!]
+    // NOTE:
+    // + Sensor comps could have been created either statically in child BPs/SetupDefault()/PostInitializeComponents()
+    // OR dynamically afterwards
+    // + Use [ForEachComponent] would cause a fatal log on [Container has changed during ranged-for iteration!]
     TInlineComponentArray<URRROS2BaseSensorComponent*> sensorComponents(this);
     for (auto& sensorComp : sensorComponents)
     {

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -38,20 +38,22 @@ void ARRBaseRobot::SetupDefault()
 
 void ARRBaseRobot::PostInitializeComponents()
 {
-    Super::PostInitializeComponents();
     if (ROS2InterfaceClass)
     {
         CreateROS2Interface();
     }
     else
     {
-        // [OnConstruction] could run in various Editor BP actions, thus could not do Fatal log here
         UE_LOG(LogRapyutaCore,
                Warning,
                TEXT("[%s] [ARRBaseRobot::PostInitializeComponents()] ROS2InterfaceClass has not been configured, "
                     "probably later in child BP class!"),
                *GetName());
     }
+
+    // Super::, for EAutoPossessAI::PlacedInWorldOrSpawned, spawn APawn's default controller,
+    // which does the possessing, thus must be called afterwards
+    Super::PostInitializeComponents();
 }
 
 void ARRBaseRobot::CreateROS2Interface()
@@ -60,6 +62,8 @@ void ARRBaseRobot::CreateROS2Interface()
         URRUObjectUtils::CreateSelfSubobject(this, ROS2InterfaceClass, FString::Printf(TEXT("%sROS2Interface"), *GetName())));
     // NOTE: NOT call ROS2Interface->Initialize(this) here since robot's ros2-based accessories might not have been fully accessible
     // yet. For sure, that would be done in Controller's OnPossess
+
+    UE_LOG(LogTemp, Error, TEXT("%ld %s ARRBaseRobot::CreateROS2Interface %ld"), this, *GetName(), ROS2Interface);
 }
 
 bool ARRBaseRobot::InitSensors(AROS2Node* InROS2Node)

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotBaseVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotBaseVehicle.cpp
@@ -70,7 +70,15 @@ bool ARRRobotBaseVehicle::InitMoveComponent()
         // to the owner actor's root
         return true;
     }
-    return false;
+    else
+    {
+        // [OnConstruction] could run in various Editor BP actions, thus could not do Fatal log here
+        UE_LOG(LogRapyutaCore,
+               Warning,
+               TEXT("[%s] [VehicleMoveComponentClass] has not been configured, probably later in child BP class!"),
+               *GetName());
+        return false;
+    }
 }
 
 void ARRRobotBaseVehicle::SetLinearVel(const FVector& InLinearVelocity)

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotBaseVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotBaseVehicle.cpp
@@ -72,7 +72,6 @@ bool ARRRobotBaseVehicle::InitMoveComponent()
     }
     else
     {
-        // [OnConstruction] could run in various Editor BP actions, thus could not do Fatal log here
         UE_LOG(LogRapyutaCore,
                Warning,
                TEXT("[%s] [VehicleMoveComponentClass] has not been configured, probably later in child BP class!"),

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotBaseVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotBaseVehicle.cpp
@@ -7,6 +7,7 @@
 #include "ROS2Node.h"
 
 // RapyutaSimulationPlugins
+#include "Core/RRUObjectUtils.h"
 #include "Drives/RobotVehicleMovementComponent.h"
 #include "Robots/RRRobotVehicleROSController.h"
 #include "Tools/ROS2Spawnable.h"
@@ -29,6 +30,17 @@ void ARRRobotBaseVehicle::SetupDefaultVehicle()
     // classes will automatically get invalidated.
     AIControllerClass = ARRRobotVehicleROSController::StaticClass();
     AutoPossessAI = EAutoPossessAI::PlacedInWorldOrSpawned;
+
+    // NOTE: Any custom object class (eg ROS2Interface Class, VehicleMoveComponentClass) that is required to be configurable by
+    // this class' child BP ones & if its object needs to be created before BeginPlay(),
+    // -> The class must be left NULL here, so its object (eg RobotVehicleMoveComponent) is not created by default in
+    // [PostInitializeComponents()]
+}
+
+void ARRRobotBaseVehicle::PostInitializeComponents()
+{
+    Super::PostInitializeComponents();
+    InitMoveComponent();
 }
 
 void ARRRobotBaseVehicle::SetRootOffset(const FTransform& InRootOffset)
@@ -44,8 +56,8 @@ bool ARRRobotBaseVehicle::InitMoveComponent()
     if (VehicleMoveComponentClass)
     {
         // (NOTE) Being created in [OnConstruction], PIE will cause this to be reset anyway, thus requires recreation
-        RobotVehicleMoveComponent = NewObject<URobotVehicleMovementComponent>(
-            this, VehicleMoveComponentClass, *FString::Printf(TEXT("%s_MoveComp"), *GetName()));
+        RobotVehicleMoveComponent = CastChecked<URobotVehicleMovementComponent>(
+            URRUObjectUtils::CreateSelfSubobject(this, VehicleMoveComponentClass, FString::Printf(TEXT("%sMoveComp"), *GetName())));
         RobotVehicleMoveComponent->RegisterComponent();
 
         // Configure custom properties (frameids, etc.)
@@ -58,12 +70,7 @@ bool ARRRobotBaseVehicle::InitMoveComponent()
         // to the owner actor's root
         return true;
     }
-    else
-    {
-        // [OnConstruction] could run in various Editor BP actions, thus could not do Fatal log here
-        UE_LOG(LogRapyutaCore, Warning, TEXT("[%s] [VehicleMoveComponentClass] has not been configured!"), *GetName());
-        return false;
-    }
+    return false;
 }
 
 void ARRRobotBaseVehicle::SetLinearVel(const FVector& InLinearVelocity)
@@ -74,10 +81,4 @@ void ARRRobotBaseVehicle::SetLinearVel(const FVector& InLinearVelocity)
 void ARRRobotBaseVehicle::SetAngularVel(const FVector& InAngularVelocity)
 {
     RobotVehicleMoveComponent->AngularVelocity = InAngularVelocity;
-}
-
-void ARRRobotBaseVehicle::PostInitializeComponents()
-{
-    Super::PostInitializeComponents();
-    InitMoveComponent();
 }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
@@ -16,6 +16,7 @@
 void URRRobotROS2Interface::Initialize(ARRBaseRobot* InRobot)
 {
     Robot = InRobot;
+    Robot->ROS2Interface = this;
 
     // Instantiate a ROS2 node for each possessed [InPawn]
     InitRobotROS2Node(InRobot);

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
@@ -18,7 +18,7 @@ void URRRobotROS2Interface::Initialize(ARRBaseRobot* InRobot)
     Robot = InRobot;
     Robot->ROS2Interface = this;
 
-    // Instantiate a ROS2 node for each possessed [InPawn]
+    // Instantiate a ROS2 node for InRobot
     InitRobotROS2Node(InRobot);
 
     // Initialize Robot's sensors (lidar, etc.)

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
@@ -69,7 +69,8 @@ bool URRRobotROS2Interface::InitPublishers()
             OdomPublisher->bPublishOdomTf = bPublishOdomTf;
         }
         OdomPublisher->InitializeWithROS2(RobotROS2Node);
-        OdomPublisher->RobotVehicle = Cast<ARRRobotBaseVehicle>(Robot);
+        // If publishing odom, it must be an [ARRRobotBaseVehicle]
+        OdomPublisher->RobotVehicle = CastChecked<ARRRobotBaseVehicle>(Robot);
     }
     return true;
 }
@@ -124,13 +125,10 @@ void URRRobotROS2Interface::MovementCallback(const UROS2GenericMsg* Msg)
         AsyncTask(ENamedThreads::GameThread,
                   [this, linear, angular]
                   {
-                      ARRRobotBaseVehicle* robotVehicle = Cast<ARRRobotBaseVehicle>(Robot);
-                      if (robotVehicle)
-                      {
-                          check(IsValid(robotVehicle));
-                          robotVehicle->SetLinearVel(linear);
-                          robotVehicle->SetAngularVel(angular);
-                      }
+                      ARRRobotBaseVehicle* robotVehicle = CastChecked<ARRRobotBaseVehicle>(Robot);
+                      check(IsValid(robotVehicle));
+                      robotVehicle->SetLinearVel(linear);
+                      robotVehicle->SetAngularVel(angular);
                   });
     }
 }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
@@ -10,9 +10,10 @@
 // RapyutaSimulationPlugins
 #include "Core/RRConversionUtils.h"
 #include "Core/RRGeneralUtils.h"
-#include "Robots/RobotVehicle.h"
+#include "Robots/RRBaseRobot.h"
+#include "Robots/RRRobotBaseVehicle.h"
 
-void URRRobotROS2Interface::Initialize(ARobotVehicle* InRobot)
+void URRRobotROS2Interface::Initialize(ARRBaseRobot* InRobot)
 {
     Robot = InRobot;
 
@@ -27,7 +28,7 @@ void URRRobotROS2Interface::Initialize(ARobotVehicle* InRobot)
     InitSubscriptions();
 }
 
-void URRRobotROS2Interface::InitRobotROS2Node(ARobotVehicle* InRobot)
+void URRRobotROS2Interface::InitRobotROS2Node(ARRBaseRobot* InRobot)
 {
     if (nullptr == RobotROS2Node)
     {
@@ -67,7 +68,7 @@ bool URRRobotROS2Interface::InitPublishers()
             OdomPublisher->bPublishOdomTf = bPublishOdomTf;
         }
         OdomPublisher->InitializeWithROS2(RobotROS2Node);
-        OdomPublisher->RobotVehicle = Robot;
+        OdomPublisher->RobotVehicle = Cast<ARRRobotBaseVehicle>(Robot);
     }
     return true;
 }
@@ -122,9 +123,13 @@ void URRRobotROS2Interface::MovementCallback(const UROS2GenericMsg* Msg)
         AsyncTask(ENamedThreads::GameThread,
                   [this, linear, angular]
                   {
-                      check(IsValid(Robot));
-                      Robot->SetLinearVel(linear);
-                      Robot->SetAngularVel(angular);
+                      ARRRobotBaseVehicle* robotVehicle = Cast<ARRRobotBaseVehicle>(Robot);
+                      if (robotVehicle)
+                      {
+                          check(IsValid(robotVehicle));
+                          robotVehicle->SetLinearVel(linear);
+                          robotVehicle->SetAngularVel(angular);
+                      }
                   });
     }
 }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
@@ -23,12 +23,8 @@ void ARRRobotVehicleROSController::OnPossess(APawn* InPawn)
     // + InPawn's child class' ros2-related accessories (ROS2 node, sensors, publishers/subscribers)
     //  may have not been fully accessible until now
     auto* robotVehicle = CastChecked<ARRRobotBaseVehicle>(InPawn);
-    if (robotVehicle->ROS2Interface == nullptr)
-    {
-        robotVehicle->CreateROS2Interface();
-    }
+    verify(IsValid(robotVehicle->ROS2Interface));
     ROS2Interface = robotVehicle->ROS2Interface;
-    verify(ROS2Interface);
     ROS2Interface->Initialize(robotVehicle);
 }
 

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
@@ -9,8 +9,8 @@
 #include "ROS2Node.h"
 
 // RapyutaSimulationPlugins
+#include "Robots/RRRobotBaseVehicle.h"
 #include "Robots/RRRobotROS2Interface.h"
-#include "Robots/RobotVehicle.h"
 
 void ARRRobotVehicleROSController::OnPossess(APawn* InPawn)
 {
@@ -19,12 +19,12 @@ void ARRRobotVehicleROSController::OnPossess(APawn* InPawn)
     // Create ROS2 interface
     if (nullptr == ROS2Interface)
     {
-        ARobotVehicle* robot = CastChecked<ARobotVehicle>(InPawn);
+        ARRRobotBaseVehicle* robot = CastChecked<ARRRobotBaseVehicle>(InPawn);
         verify(robot->ROS2InterfaceClass);
         ROS2Interface = CastChecked<URRRobotROS2Interface>(URRUObjectUtils::CreateSelfSubobject(
             this, robot->ROS2InterfaceClass, FString::Printf(TEXT("%sROS2Interface"), *GetName())));
     }
-    ROS2Interface->Initialize(CastChecked<ARobotVehicle>(InPawn));
+    ROS2Interface->Initialize(CastChecked<ARRRobotBaseVehicle>(InPawn));
 }
 
 void ARRRobotVehicleROSController::OnUnPossess()

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotVehicleROSController.cpp
@@ -23,7 +23,7 @@ void ARRRobotVehicleROSController::OnPossess(APawn* InPawn)
     // + InPawn's child class' ros2-related accessories (ROS2 node, sensors, publishers/subscribers)
     //  may have not been fully accessible until now
     auto* robotVehicle = CastChecked<ARRRobotBaseVehicle>(InPawn);
-    if (nullptr == robotVehicle->ROS2Interface)
+    if (robotVehicle->ROS2Interface == nullptr)
     {
         robotVehicle->CreateROS2Interface();
     }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCrowdAIController.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCrowdAIController.h
@@ -1,0 +1,19 @@
+/**
+ * @file RRCrowdAIController.h
+ * @brief Base Crowd AI Controller for Character-based classes, utilizing UCrowdFollowingComponent
+ * @copyright Copyright 2020-2022 Rapyuta Robotics Co., Ltd.
+ */
+
+#pragma once
+
+#include "AIController.h"
+
+#include "RRCrowdAIController.generated.h"
+
+UCLASS()
+class RAPYUTASIMULATIONPLUGINS_API ARRCrowdAIController : public AAIController
+{
+    GENERATED_BODY()
+public:
+    ARRCrowdAIController(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+};

--- a/Source/RapyutaSimulationPlugins/Public/Drives/RobotVehicleMovementComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/RobotVehicleMovementComponent.h
@@ -11,9 +11,7 @@
 
 // UE
 #include "CoreMinimal.h"
-#include "GameFramework/Actor.h"
-#include "GameFramework/FloatingPawnMovement.h"
-#include "Kismet/GameplayStatics.h"
+#include "GameFramework/PawnMovementComponent.h"
 
 // rclUE
 #include "Msgs/ROS2OdometryMsg.h"
@@ -48,7 +46,7 @@ enum class EOdomSource : uint8
  * @todo Expose odom covariance parameter.
  */
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
-class RCLUE_API URobotVehicleMovementComponent : public UPawnMovementComponent
+class RAPYUTASIMULATIONPLUGINS_API URobotVehicleMovementComponent : public UPawnMovementComponent
 {
     GENERATED_BODY()
 

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -56,6 +56,7 @@ public:
     //! Robot's ROS2 Interface
     UPROPERTY()
     URRRobotROS2Interface* ROS2Interface = nullptr;
+    void CreateROS2Interface();
 
     /**
      * @brief
@@ -148,4 +149,10 @@ public:
      */
     // UFUNCTION(BlueprintCallable)
     virtual void SetJointState(const TMap<FString, TArray<float>>& InJointState, const ERRJointControlType InJointControlType);
+
+protected:
+    /**
+     * @brief Instantiate default child components
+     */
+    virtual void PostInitializeComponents() override;
 };

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -53,6 +53,10 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (DisplayName = "ROS2 Interface Class"))
     TSubclassOf<URRRobotROS2Interface> ROS2InterfaceClass;
 
+    //! Robot's ROS2 Interface
+    UPROPERTY()
+    URRRobotROS2Interface* ROS2Interface = nullptr;
+
     /**
      * @brief
      * Actually Object's Name is also unique as noted by UE, but we just do not want to rely on it.

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotBaseVehicle.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotBaseVehicle.h
@@ -7,10 +7,7 @@
 #pragma once
 
 // UE
-#include "Components/SkeletalMeshComponent.h"
 #include "CoreMinimal.h"
-#include "Engine/TargetPoint.h"
-#include "GameFramework/Pawn.h"
 
 // RapyutaSimulationPlugins
 #include "Drives/RRJointComponent.h"
@@ -23,7 +20,6 @@
 
 #include "RRRobotBaseVehicle.generated.h"
 
-class URRRobotROS2Interface;
 class URobotVehicleMovementComponent;
 
 /**
@@ -51,14 +47,24 @@ public:
      */
     ARRRobotBaseVehicle(const FObjectInitializer& ObjectInitializer);
 
+    /**
+     * @brief Initialize vehicle default
+     *
+     */
+    void SetupDefaultVehicle();
+
     //! reference actor for odometry.
     //! @todo is this still necessary?
     UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ExposeOnSpawn = "true"))
     AActor* Map = nullptr;
 
+    // KINEMATIC MOVEMENT --
+    //
+    //! Main robot vehicle move component
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     URobotVehicleMovementComponent* RobotVehicleMoveComponent = nullptr;
 
+    //! Class of the main robot vehicle move component, configurable in child class
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     TSubclassOf<URobotVehicleMovementComponent> VehicleMoveComponentClass;
 
@@ -69,12 +75,6 @@ public:
      * @return false
      */
     virtual bool InitMoveComponent();
-
-    /**
-     * @brief Initialize vehicle default
-     *
-     */
-    void SetupDefaultVehicle();
 
     /**
      * @brief Set the root offset for #RobotVehicleMoveComponent
@@ -109,7 +109,6 @@ protected:
      * @sa[PostInitializeComponents](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/GameFramework/AActor/PostInitializeComponents/)
      */
     virtual void PostInitializeComponents() override;
-
     /**
      * @brief This method is called inside #PostInitializeComponents.
      * Custom initialization of child class can be done by overwritting this method.

--- a/Source/RapyutaSimulationPlugins/RapyutaSimulationPlugins.Build.cs
+++ b/Source/RapyutaSimulationPlugins/RapyutaSimulationPlugins.Build.cs
@@ -43,7 +43,8 @@ public class RapyutaSimulationPlugins : ModuleRules
         CppStandard = CppStandardVersion.Cpp17;
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "Renderer", "RHI", "AIModule", "PhysicsCore",
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "Renderer", "RHI", "PhysicsCore",
+                                                            "AIModule",  "NavigationSystem",
                                                             "ProceduralMeshComponent", "MeshDescription", "StaticMeshDescription", "MeshConversion",
                                                             "rclUE"});
 


### PR DESCRIPTION
* RobotVehicleROSController: ARobotVehicle -> ARRRobotBaseVehicle
* Add ARRCrowAIController due to [ADetourCrowdAIController](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/AIModule/Classes/DetourCrowdAIController.h#L12) lacks module API tag, thus not compilable in EDITOR build
* `ARRBaseRobot` add ROS2Interface member & `CreateRobotROS2Interface()`, only instantiating it upon valid ROS2InterfaceClass
* Add Scripts/verify_ue4_env.sh, so users could use a common custom env var (as path to UE4Editor) for all running scripts in client project repos
* `URRRobotROS2Interface` Add `OnMessageReceived()`, being used as a generic class callback, eg [here](https://github.com/rapyuta-robotics/RapyutaSimulationInternal/blob/SOOTBALL_SIM/Source/RapyutaSimInternal/Private/Sootball/RRSootballROS2Interface.cpp#L109).