### PR TITLE
Add RRFloatingMovementComponent

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRMeshActor.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRMeshActor.cpp
@@ -16,6 +16,7 @@ ARRMeshActor::ARRMeshActor()
 {
     // CREATE & SETUP A SCENE COMPONENT AS ROOT
     // -> THIS IS REQUIRED TO ALLOW ACTOR BEING SPAWNED WITH A USER TRANSFORM, WHICH IS APPLIED TO THE SCENE-COMPONENT ROOT
+    // Refer to [AActor::PostSpawnInitialize()]
     URRUObjectUtils::SetupDefaultRootComponent(this);
 
     bLastMeshCreationResult = false;

--- a/Source/RapyutaSimulationPlugins/Private/Drives/RRFloatingMovementComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/RRFloatingMovementComponent.cpp
@@ -2,6 +2,14 @@
 
 #include "Drives/RRFloatingMovementComponent.h"
 
+URRFloatingMovementComponent::URRFloatingMovementComponent(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+    // NOTE: Let itself be manually activated & tick then to wait for [ExemptedCollidingCompList] to be confirmed
+    bAutoActivate = false;
+    bAutoUpdateTickRegistration = false;
+    bTickBeforeOwner = false;
+}
+
 void URRFloatingMovementComponent::TickComponent(float InDeltaTime,
                                                  enum ELevelTick InTickType,
                                                  FActorComponentTickFunction* InTickFunction)
@@ -36,7 +44,7 @@ void URRFloatingMovementComponent::TickComponent(float InDeltaTime,
         Velocity = Velocity.GetUnsafeNormal() * MaxSpeed;
     }
 
-    LimitWorldBounds();
+    //LimitWorldBounds();
     bPositionCorrected = false;
 
     // Move [UpdatedComponent], updating [bPositionCorrected] here-in
@@ -46,7 +54,7 @@ void URRFloatingMovementComponent::TickComponent(float InDeltaTime,
         // Save prevLocation
         const FVector prevLocation = UpdatedComponent->GetComponentLocation();
         FHitResult hit(1.f);
-        SafeMoveUpdatedComponent(deltaLoc, UpdatedComponent->GetComponentQuat(), bSweepEnabled, hit);
+        SafeMoveTargetWithCollisionExemption(deltaLoc, UpdatedComponent->GetComponentQuat(), bSweepEnabled, hit);
 
         if (hit.IsValidBlockingHit())
         {
@@ -64,4 +72,199 @@ void URRFloatingMovementComponent::TickComponent(float InDeltaTime,
 
     // Update [UpdatedComponent]'s Velocity by [Velocity]
     UpdateComponentVelocity();
+}
+
+bool URRFloatingMovementComponent::ResolvePenetrationImpl(const FVector& InProposedAdjustment,
+                                                          const FHitResult& InHit,
+                                                          const FQuat& InNewRotationQuat)
+{
+    // NOTE: THIS IS REIMPLEMENTATION, DON'T CALL SUPER::
+    // SceneComponent can't be in penetration, so this function really only applies to PrimitiveComponent.
+    const FVector constrainedAdjustment = ConstrainDirectionToPlane(InProposedAdjustment);
+    if (!constrainedAdjustment.IsZero() && UpdatedPrimitive)
+    {
+        QUICK_SCOPE_CYCLE_COUNTER(STAT_MovementComponent_ResolvePenetration);
+        // See if we can fit at the adjusted location without overlapping anything.
+        AActor* ownerActor = UpdatedComponent->GetOwner();
+        if (!ownerActor)
+        {
+            return false;
+        }
+
+#if 1    // RAPYUTA_SIM_DEBUG
+        UE_LOG(LogRapyutaCore,
+               Error,
+               TEXT("ResolvePenetration: %s.%s at location %s inside %s.%s at location %s by %.3f (netmode: %d)"),
+               *ownerActor->GetName(),
+               *UpdatedComponent->GetName(),
+               *UpdatedComponent->GetComponentLocation().ToString(),
+               *GetNameSafe(InHit.GetActor()),
+               *GetNameSafe(InHit.GetComponent()),
+               InHit.Component.IsValid() ? *InHit.GetComponent()->GetComponentLocation().ToString() : TEXT("<unknown>"),
+               InHit.PenetrationDepth,
+               static_cast<uint32>(GetNetMode()));
+#endif
+
+        if (ExemptedCollidingCompList.Contains(InHit.GetComponent()))
+        {
+#if 1    // RAPYUTA_SIM_DEBUG
+            UE_LOG(LogRapyutaCore,
+                   Error,
+                   TEXT("%s ResolvePenetrationImpl - EXEMPTED hit comp %s"),
+                   *GetName(),
+                   *InHit.GetComponent()->GetName());
+#endif
+            // Retry original move WITHOUT Sweep
+            MoveUpdatedComponent(constrainedAdjustment, InNewRotationQuat, false, nullptr, ETeleportType::TeleportPhysics);
+            return true;
+        }
+
+        // We really want to make sure that precision differences or differences between the overlap test and sweep tests don't put us into another overlap,
+        // so make the overlap test a bit more restrictive.
+        const float overlapInflation = 0.1f;    // MovementComponentCVars::PenetrationOverlapCheckInflation;
+        bool bEncroached = OverlapTest(InHit.TraceStart + constrainedAdjustment,
+                                       InNewRotationQuat,
+                                       UpdatedPrimitive->GetCollisionObjectType(),
+                                       UpdatedPrimitive->GetCollisionShape(overlapInflation),
+                                       ownerActor);
+        if (!bEncroached)
+        {
+            // Move without sweeping.
+            MoveUpdatedComponent(constrainedAdjustment, InNewRotationQuat, false, nullptr, ETeleportType::TeleportPhysics);
+#if 1    // RAPYUTA_SIM_DEBUG
+            UE_LOG(LogRapyutaCore, Error, TEXT("ResolvePenetration: teleport by %s"), *constrainedAdjustment.ToString());
+#endif
+            return true;
+        }
+        else
+        {
+            // Disable MOVECOMP_NeverIgnoreBlockingOverlaps if it is enabled, otherwise we wouldn't be able to sweep out of the object to fix the penetration.
+            TGuardValue<EMoveComponentFlags> ScopedFlagRestore(
+                MoveComponentFlags, EMoveComponentFlags(MoveComponentFlags & (~MOVECOMP_NeverIgnoreBlockingOverlaps)));
+
+            // Try sweeping as far as possible...
+            FHitResult outSweepHit(1.f);
+            bool bMoved =
+                MoveUpdatedComponent(constrainedAdjustment, InNewRotationQuat, true, &outSweepHit, ETeleportType::TeleportPhysics);
+
+#if 1    // RAPYUTA_SIM_DEBUG
+            UE_LOG(LogRapyutaCore,
+                   Error,
+                   TEXT("ResolvePenetration: sweep by %s (success = %d)"),
+                   *constrainedAdjustment.ToString(),
+                   bMoved);
+#endif
+
+            // Try sweep again - 1st
+            if (!bMoved && outSweepHit.bStartPenetrating)
+            {
+                // Combine two MTD results to get a new direction that gets out of multiple surfaces.
+                const FVector secondMTD = GetPenetrationAdjustment(outSweepHit);
+                const FVector combinedMTD = constrainedAdjustment + secondMTD;
+                if (secondMTD != constrainedAdjustment && !combinedMTD.IsZero())
+                {
+                    bMoved = MoveUpdatedComponent(combinedMTD, InNewRotationQuat, true, nullptr, ETeleportType::TeleportPhysics);
+#if 1    // RAPYUTA_SIM_DEBUG
+                    UE_LOG(LogRapyutaCore,
+                           Error,
+                           TEXT("ResolvePenetration: sweep by %s (MTD combo success = %d)"),
+                           *combinedMTD.ToString(),
+                           bMoved);
+#endif
+                }
+            }
+
+            // Try sweep again - 2nd
+            if (!bMoved)
+            {
+                // Try moving the proposed adjustment plus the attempted move direction. This can sometimes get out of penetrations with multiple objects
+                const FVector moveDelta = ConstrainDirectionToPlane(InHit.TraceEnd - InHit.TraceStart);
+                if (!moveDelta.IsZero())
+                {
+                    bMoved = MoveUpdatedComponent(
+                        constrainedAdjustment + moveDelta, InNewRotationQuat, true, nullptr, ETeleportType::TeleportPhysics);
+#if 1    // RAPYUTA_SIM_DEBUG
+                    UE_LOG(LogRapyutaCore,
+                           Error,
+                           TEXT("ResolvePenetration: sweep by %s (adjusted attempt success = %d)"),
+                           *(constrainedAdjustment + moveDelta).ToString(),
+                           bMoved);
+#endif
+
+                    // Finally, try the original move without MTD adjustments, but allowing depenetration along the MTD normal.
+                    // This was blocked because MOVECOMP_NeverIgnoreBlockingOverlaps was true for the original move to try a better depenetration normal, but we might be running in to other geometry in the attempt.
+                    // This won't necessarily get us all the way out of penetration, but can in some cases and does make progress in exiting the penetration.
+                    if (!bMoved && FVector::DotProduct(moveDelta, constrainedAdjustment) > 0.f)
+                    {
+                        bMoved = MoveUpdatedComponent(moveDelta, InNewRotationQuat, true, nullptr, ETeleportType::TeleportPhysics);
+#if 1    // RAPYUTA_SIM_DEBUG
+                        UE_LOG(LogRapyutaCore,
+                               Error,
+                               TEXT("ResolvePenetration:   sweep by %s (Original move, attempt success = %d)"),
+                               *(moveDelta).ToString(),
+                               bMoved);
+#endif
+                    }
+                }
+            }
+
+            return bMoved;
+        }
+    }
+
+    return false;
+}
+
+bool URRFloatingMovementComponent::SafeMoveTargetWithCollisionExemption(const FVector& InDeltaLoc,
+                                                                        const FQuat& InNewRotation,
+                                                                        bool bSweep,
+                                                                        FHitResult& OutHit,
+                                                                        const ETeleportType InTeleportType)
+{
+    if (UpdatedComponent == NULL)
+    {
+        OutHit.Reset(1.f);
+        return false;
+    }
+
+    bool bMoveResult = false;
+
+    // Scope for move flags
+    {
+        // NOT IGNORE blocking overlaps
+        const EMoveComponentFlags IncludeBlockingOverlapsWithoutEvents =
+            (MOVECOMP_NeverIgnoreBlockingOverlaps | MOVECOMP_DisableBlockingOverlapDispatch);
+        TGuardValue<EMoveComponentFlags> ScopedFlagRestore(
+            MoveComponentFlags,
+            //MovementComponentCVars::MoveIgnoreFirstBlockingOverlap
+            false ? MoveComponentFlags : (MoveComponentFlags | IncludeBlockingOverlapsWithoutEvents));
+        bMoveResult = MoveUpdatedComponent(InDeltaLoc, InNewRotation, bSweep, &OutHit, InTeleportType);
+    }
+
+    // Handle initial penetration
+    if (OutHit.bStartPenetrating && UpdatedComponent)
+    {
+        if (ExemptedCollidingCompList.Contains(OutHit.GetComponent()))
+        {
+#if 1    // RAPYUTA_SIM_DEBUG
+            UE_LOG(LogRapyutaCore,
+                   Error,
+                   TEXT("%s Handle initial penetration - EXEMPTED hit comp %s"),
+                   *GetName(),
+                   *OutHit.GetComponent()->GetName());
+#endif
+            // Retry original move WITHOUT Sweep
+            bMoveResult = MoveUpdatedComponent(InDeltaLoc, InNewRotation, false, &OutHit, InTeleportType);
+        }
+        else
+        {
+            if (ResolvePenetration(GetPenetrationAdjustment(OutHit), OutHit, InNewRotation))
+            {
+                // Retry original move
+                bMoveResult = MoveUpdatedComponent(InDeltaLoc, InNewRotation, bSweep, &OutHit, InTeleportType);
+            }
+        }
+    }
+
+    return bMoveResult;
 }

--- a/Source/RapyutaSimulationPlugins/Private/Drives/RRFloatingMovementComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/RRFloatingMovementComponent.cpp
@@ -1,0 +1,67 @@
+// Copyright 2020-2021 Rapyuta Robotics Co., Ltd.
+
+#include "Drives/RRFloatingMovementComponent.h"
+
+void URRFloatingMovementComponent::TickComponent(float InDeltaTime,
+                                                 enum ELevelTick InTickType,
+                                                 FActorComponentTickFunction* InTickFunction)
+{
+    if (ShouldSkipUpdate(InDeltaTime))
+    {
+        return;
+    }
+
+    // NOTE: Here we implement custom movement, Don't call Super::, which already auto updates Owner actor's velocity & pose
+    UMovementComponent::TickComponent(InDeltaTime, InTickType, InTickFunction);
+
+    if (!PawnOwner || !UpdatedComponent)
+    {
+        return;
+    }
+
+    const AController* controller = PawnOwner->GetController();
+    if (false == (controller && controller->IsLocalController()))
+    {
+        return;
+    }
+
+    // Apply input for local players but also for AI that's not following a navigation path at the moment
+    if (controller->IsLocalPlayerController() || (false == controller->IsFollowingAPath()) || bUseAccelerationForPaths)
+    {
+        ApplyControlInputToVelocity(InDeltaTime);
+    }
+    // Limit speed in case of non-path-following AI controller
+    else if (IsExceedingMaxSpeed(MaxSpeed) == true)
+    {
+        Velocity = Velocity.GetUnsafeNormal() * MaxSpeed;
+    }
+
+    LimitWorldBounds();
+    bPositionCorrected = false;
+
+    // Move [UpdatedComponent], updating [bPositionCorrected] here-in
+    FVector deltaLoc = Velocity * InDeltaTime;
+    if (!deltaLoc.IsNearlyZero(1e-6f))
+    {
+        // Save prevLocation
+        const FVector prevLocation = UpdatedComponent->GetComponentLocation();
+        FHitResult hit(1.f);
+        SafeMoveUpdatedComponent(deltaLoc, UpdatedComponent->GetComponentQuat(), bSweepEnabled, hit);
+
+        if (hit.IsValidBlockingHit())
+        {
+            HandleImpact(hit, InDeltaTime, deltaLoc);
+            // Slide the remaining distance along the hit surface
+            SlideAlongSurface(deltaLoc, 1.f - hit.Time, hit.Normal, hit, bSweepEnabled);
+        }
+
+        // Update [Velocity], only if not already [bPositionCorrected] possibly due to penetration fixup
+        if (false == bPositionCorrected)
+        {
+            Velocity = ((UpdatedComponent->GetComponentLocation() - prevLocation) / InDeltaTime);
+        }
+    }
+
+    // Update [UpdatedComponent]'s Velocity by [Velocity]
+    UpdateComponentVelocity();
+}

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RobotVehicle.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RobotVehicle.cpp
@@ -32,6 +32,9 @@ void ARobotVehicle::SetupDefaultRootSkeletal()
     SkeletalMeshComp = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("SkeletalMeshComp"));
     SkeletalMeshComp->VisibilityBasedAnimTickOption = EVisibilityBasedAnimTickOption::AlwaysTickPose;
     SkeletalMeshComp->SetCollisionProfileName(UCollisionProfile::Pawn_ProfileName);
+    SkeletalMeshComp->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+    SkeletalMeshComp->SetCanEverAffectNavigation(true);
+    SkeletalMeshComp->SetIsReplicated(true);
     AddOwnedComponent(SkeletalMeshComp);
     RootComponent = SkeletalMeshComp;
 

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RRPoseSensorManager.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RRPoseSensorManager.cpp
@@ -34,7 +34,7 @@ void URRPoseSensorManager::InitalizeWithROS2(AROS2Node* InROS2Node,
                                              const FString& InTopicName,
                                              const TEnumAsByte<UROS2QoS> InQoS)
 {
-    UE_LOG(LogRapyutaCore, Error, TEXT("[%s][URRPoseSensorManager][InitalizeWithROS2] %s"), *GetName(), *ReferenceTag);
+    UE_LOG(LogRapyutaCore, Warning, TEXT("[%s][URRPoseSensorManager][InitalizeWithROS2] %s"), *GetName(), *ReferenceTag);
     Super::InitalizeWithROS2(InROS2Node, InPublisherName, InTopicName, InQoS);
     MapOriginPoseSensor->InitalizeWithROS2(InROS2Node);
     ServerSimState = CastChecked<ASimulationState>(UGameplayStatics::GetActorOfClass(GetWorld(), ASimulationState::StaticClass()));
@@ -103,10 +103,19 @@ void URRPoseSensorManager::UpdateReferenceActorWithTag()
     {
         if (nearestActor != ReferenceActor)
         {
-            SetReferenceActorByActor(nearestActor);
+            // 1- Attach [MapOriginPoseSensor] to [nearestActor]
             MapOriginPoseSensor->DetachFromComponent(FDetachmentTransformRules::KeepRelativeTransform);
             MapOriginPoseSensor->AttachToComponent(nearestActor->GetRootComponent(),
                                                    FAttachmentTransformRules::KeepRelativeTransform);
+            UE_LOG(LogRapyutaCore,
+                   Warning,
+                   TEXT("[%s]'s [MapOriginPoseSensor] attached to [%s]'s comp: %s"),
+                   *GetName(),
+                   *nearestActor->GetName(),
+                   *nearestActor->GetRootComponent()->GetName());
+
+            // 2- Update [ReferenceActor] -> [nearestActor], signalling [OnNewReferenceActorDetected]
+            SetReferenceActorByActor(nearestActor);
         }
     }
     else

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2EntityStateSensorComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2EntityStateSensorComponent.cpp
@@ -18,14 +18,33 @@ void URRROS2EntityStateSensorComponent::BeginPlay()
 
 void URRROS2EntityStateSensorComponent::SetReferenceActorByName(const FString& InName)
 {
-    ReferenceActor = URRUObjectUtils::FindActorByName<AActor>(GetWorld(), InName);
-    ReferenceActorName = InName;
+    AActor* newReferenceActor = URRUObjectUtils::FindActorByName<AActor>(GetWorld(), InName);
+    if (newReferenceActor)
+    {
+        const bool bNewReference = (ReferenceActor != newReferenceActor);
+        ReferenceActor = newReferenceActor;
+        ReferenceActorName = InName;
+        if (bNewReference)
+        {
+            OnNewReferenceActorDetected.Broadcast(newReferenceActor);
+        }
+    }
+    else
+    {
+        UE_LOG(
+            LogRapyutaCore, Error, TEXT("[URRROS2EntityStateSensorComponent::SetReferenceActorByName] %s is not found"), *InName);
+    }
 }
 
 void URRROS2EntityStateSensorComponent::SetReferenceActorByActor(AActor* InActor)
 {
+    const bool bNewReference = (ReferenceActor != InActor);
     ReferenceActor = InActor;
     ReferenceActorName = ReferenceActor->GetName();
+    if (bNewReference)
+    {
+        OnNewReferenceActorDetected.Broadcast(InActor);
+    }
 }
 
 FROSEntityState URRROS2EntityStateSensorComponent::GetROS2Data()

--- a/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
@@ -386,19 +386,23 @@ AActor* ASimulationState::ServerSpawnEntity(const FROSSpawnEntityReq& InRequest,
             // Calculate to-be-spawned entity's [world transf]
             FTransform relativeTransf =
                 URRConversionUtils::TransformROSToUE(FTransform(InRequest.State.Pose.Orientation, InRequest.State.Pose.Position));
+            const FString& referenceFrame = InRequest.State.ReferenceFrame;
             FTransform worldTransf;
-            URRGeneralUtils::GetWorldTransform(
-                InRequest.State.ReferenceFrame, Entities.FindRef(InRequest.State.ReferenceFrame), relativeTransf, worldTransf);
-            UE_LOG(LogRapyutaCore,
-                   Warning,
-                   TEXT("Spawning Entity of model [%s] as [%s] to pose: %s"),
-                   *entityModelName,
-                   *entityName,
-                   *worldTransf.ToString());
+            URRGeneralUtils::GetWorldTransform(referenceFrame, Entities.FindRef(referenceFrame), relativeTransf, worldTransf);
 
             // Spawn entity
             newEntity = ServerSpawnEntity(InRequest, SpawnableEntityTypes[entityModelName], worldTransf, InNetworkPlayerId);
-            if (nullptr == newEntity)
+            if (newEntity)
+            {
+                UE_LOG(LogRapyutaCore,
+                       Warning,
+                       TEXT("Spawned Entity of model [%s] as [%s] to world pose: %s - ReferenceFrame: %s"),
+                       *entityModelName,
+                       *entityName,
+                       *worldTransf.ToString(),
+                       *referenceFrame);
+            }
+            else
             {
                 // todo: need pass response to SimulationStateClient
                 // response.bSuccess = false;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -508,6 +508,9 @@ public:
     static constexpr int8 IMAGE_BIT_DEPTH_FLOAT16 = 16;
     static constexpr int8 IMAGE_BIT_DEPTH_FLOAT32 = 32;
 
+    static constexpr const TCHAR* MAP_ORIGIN_TAG = TEXT("map_origin");
+    static constexpr const TCHAR* MAP_ROS_FRAME_ID = TEXT("map");
+
     //! Game mode handle
     UPROPERTY()
     ARRGameMode* GameMode = nullptr;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
@@ -139,8 +139,8 @@ public:
         }
 
         // Change RootComponent -> BaseMeshComp
-        // Base Mesh Component Configs
-        if ((nullptr == BaseMeshComp) && (MeshCompList.Num() > 0) /*&& (MeshCompList.Num() == ToBeCreatedMeshesNum)*/)
+        // NOTE: If we are in mid of loading up other mesh comps, changing root mid-way could disrupt the component hiearchy
+        if ((nullptr == BaseMeshComp) && (MeshCompList.Num() > 0) && (MeshCompList.Num() == ToBeCreatedMeshesNum))
         {
             BaseMeshComp = MeshCompList[0];
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
@@ -141,7 +141,7 @@ public:
 
         // Change RootComponent -> BaseMeshComp
         // Base Mesh Component Configs
-        if ((nullptr == BaseMeshComp) && (MeshCompList.Num() > 0) && (MeshCompList.Num() == ToBeCreatedMeshesNum))
+        if ((nullptr == BaseMeshComp) && (MeshCompList.Num() > 0) /*&& (MeshCompList.Num() == ToBeCreatedMeshesNum)*/)
         {
             BaseMeshComp = MeshCompList[0];
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
@@ -100,13 +100,12 @@ public:
                 continue;
             }
 
-            static int64 count = 0;
             // [OBJECT MESH COMP] --
             //
             meshComp = URRUObjectUtils::CreateMeshComponent<TMeshComp>(
                 this,
                 meshUniqueName,
-                FString::Printf(TEXT("%s_MeshComp_%ld"), *ActorInfo->UniqueName, count++),
+                FString::Printf(TEXT("%s_MeshComp_%u"), *ActorInfo->UniqueName, MeshCompList.Num()),
                 InMeshRelTransf.IsValidIndex(i) ? InMeshRelTransf[i] : FTransform::Identity,
                 ActorInfo->bIsStationary,
                 ActorInfo->bIsPhysicsEnabled,

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
@@ -139,20 +139,23 @@ public:
         }
 
         // Change RootComponent -> BaseMeshComp
-        // NOTE: If we are in mid of loading up other mesh comps, changing root mid-way could disrupt the component hiearchy
-        if ((nullptr == BaseMeshComp) && (MeshCompList.Num() > 0) && (MeshCompList.Num() == ToBeCreatedMeshesNum))
+        if ((nullptr == BaseMeshComp) && (MeshCompList.Num() > 0))
         {
             BaseMeshComp = MeshCompList[0];
 
-            // Set as Root Component
-            // Set the main mesh comp as the root
-            // (Not clear why using the default scene component as the root just disrupts actor-children relative movement,
-            // and thus also compromise the actor transform itself)!
-            if (RootComponent)
+            if (BaseMeshComp->GetRelativeTransform().Equals(FTransform::Identity))
             {
-                RootComponent->DestroyComponent();
+                // Set as Root Component
+                // Set the main mesh comp as the root
+                // (Not clear why using the default scene component as the root just disrupts actor-children relative movement,
+                // and thus also compromise the actor transform itself)!
+                USceneComponent* oldRoot = RootComponent;
+                SetRootComponent(BaseMeshComp);
+                if (oldRoot)
+                {
+                    oldRoot->DestroyComponent();
+                }
             }
-            SetRootComponent(BaseMeshComp);
         }
 
         return addedMeshCompList;

--- a/Source/RapyutaSimulationPlugins/Public/Drives/RRFloatingMovementComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/RRFloatingMovementComponent.h
@@ -20,9 +20,25 @@ class RAPYUTASIMULATIONPLUGINS_API URRFloatingMovementComponent : public UFloati
     GENERATED_BODY()
 
 public:
+    URRFloatingMovementComponent()
+    {
+    }
+    URRFloatingMovementComponent(const FObjectInitializer& ObjectInitializer);
     UPROPERTY()
     bool bSweepEnabled = true;
 
+    // Colliding comps to be moved through without sweep, which prevents movement upon collision
+    UPROPERTY()
+    TArray<USceneComponent*> ExemptedCollidingCompList;
+
 protected:
     virtual void TickComponent(float InDeltaTime, enum ELevelTick InTickType, FActorComponentTickFunction* InTickFunction) override;
+    virtual bool ResolvePenetrationImpl(const FVector& InProposedAdjustment,
+                                        const FHitResult& InHit,
+                                        const FQuat& InNewRotationQuat) override;
+    bool SafeMoveTargetWithCollisionExemption(const FVector& InDeltaLoc,
+                                              const FQuat& InNewRotation,
+                                              bool bSweep,
+                                              FHitResult& OutHit,
+                                              const ETeleportType InTeleportType = ETeleportType::None);
 };

--- a/Source/RapyutaSimulationPlugins/Public/Drives/RRFloatingMovementComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/RRFloatingMovementComponent.h
@@ -20,25 +20,14 @@ class RAPYUTASIMULATIONPLUGINS_API URRFloatingMovementComponent : public UFloati
     GENERATED_BODY()
 
 public:
-    URRFloatingMovementComponent()
-    {
-    }
-    URRFloatingMovementComponent(const FObjectInitializer& ObjectInitializer);
     UPROPERTY()
     bool bSweepEnabled = true;
 
-    // Colliding comps to be moved through without sweep, which prevents movement upon collision
-    UPROPERTY()
-    TArray<USceneComponent*> ExemptedCollidingCompList;
-
 protected:
     virtual void TickComponent(float InDeltaTime, enum ELevelTick InTickType, FActorComponentTickFunction* InTickFunction) override;
+#if RAPYUTA_SIM_DEBUG
     virtual bool ResolvePenetrationImpl(const FVector& InProposedAdjustment,
                                         const FHitResult& InHit,
                                         const FQuat& InNewRotationQuat) override;
-    bool SafeMoveTargetWithCollisionExemption(const FVector& InDeltaLoc,
-                                              const FQuat& InNewRotation,
-                                              bool bSweep,
-                                              FHitResult& OutHit,
-                                              const ETeleportType InTeleportType = ETeleportType::None);
+#endif
 };

--- a/Source/RapyutaSimulationPlugins/Public/Drives/RRFloatingMovementComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/RRFloatingMovementComponent.h
@@ -1,0 +1,28 @@
+/**
+ * @file RRFloatingMovementComponent.h
+ * @brief Base Robot floating movement class
+ * @copyright Copyright 2020-2022 Rapyuta Robotics Co., Ltd.
+ */
+
+#pragma once
+
+// UE
+#include "GameFramework/FloatingPawnMovement.h"
+
+#include "RRFloatingMovementComponent.generated.h"
+
+/**
+ * @brief Base Robot floating movement class
+ */
+UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
+class RAPYUTASIMULATIONPLUGINS_API URRFloatingMovementComponent : public UFloatingPawnMovement
+{
+    GENERATED_BODY()
+
+public:
+    UPROPERTY()
+    bool bSweepEnabled = true;
+
+protected:
+    virtual void TickComponent(float InDeltaTime, enum ELevelTick InTickType, FActorComponentTickFunction* InTickFunction) override;
+};

--- a/Source/RapyutaSimulationPlugins/Public/Sensors/RRPoseSensorManager.h
+++ b/Source/RapyutaSimulationPlugins/Public/Sensors/RRPoseSensorManager.h
@@ -87,7 +87,7 @@ public:
 
     //! Reference actor's tag
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Replicated)
-    FString ReferenceTag = TEXT("map_origin");
+    FString ReferenceTag = URRActorCommon::MAP_ORIGIN_TAG;
 
     //! Reference actor's selection mode
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Replicated)
@@ -95,7 +95,7 @@ public:
 
     //! Map frame id
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Replicated)
-    FString MapFrameId = TEXT("map");
+    FString MapFrameId = URRActorCommon::MAP_ROS_FRAME_ID;
 
     //! Map origin's pose sensor
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Replicated)

--- a/Source/RapyutaSimulationPlugins/Public/Sensors/RRROS2EntityStateSensorComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Sensors/RRROS2EntityStateSensorComponent.h
@@ -21,6 +21,8 @@
 
 #include "RRROS2EntityStateSensorComponent.generated.h"
 
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnNewReferenceActorDetected, AActor* /* NewReferenceActor */);
+
 /**
  * @brief EntityState sensor components which publish entitystate relative to a specific actor.
  * @todo Currently twist = ZeroVectors. Should be filled for physics actors.
@@ -45,11 +47,13 @@ public:
      */
     virtual void SensorUpdate() override;
 
+    //! NOTE: Only #URRPoseSensorManager uses #ReferenceActor
     UPROPERTY(EditAnywhere, BlueprintReadOnly)
     FString ReferenceActorName = TEXT("");
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly)
     AActor* ReferenceActor = nullptr;
+    FOnNewReferenceActorDetected OnNewReferenceActorDetected;
 
     UFUNCTION(BlueprintCallable)
     virtual void SetReferenceActorByName(const FString& InName);


### PR DESCRIPTION
* `UFloatingPawnMovement` use [sweep](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/Engine/Private/FloatingPawnMovement.cpp#L61) in its Movement api by default, which could deter the movement in case of collision during sweeping & thus unnecessary in certain case.
* Add `URRFloatingMovementComponent` inherting from `UFloatPawnMovement` with its TickComponent reimplemented, adding `bSweepEnabled` option