### PR TITLE
RRBaseRobot virtual InitSensors()

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
@@ -26,7 +26,7 @@ URRProceduralMeshComponent::URRProceduralMeshComponent(const FObjectInitializer&
     // Due to [FinishPhysicsAsyncCook] being not virtual and private, it is unable to catch [FOnAsyncPhysicsCookFinished] event
     // Thus we could only rely on [UBodySetup::bCreatedPhysicsMeshes]
     bUseAsyncCooking = true;
-    bUseComplexAsSimpleCollision = false;
+    bUseComplexAsSimpleCollision = true;
     bCanEverAffectNavigation = true;
 
     OnMeshCreationDone.BindUObject(Cast<ARRMeshActor>(GetOwner()), &ARRMeshActor::OnBodyComponentMeshCreationDone);

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -225,7 +225,7 @@ public:
      * @sa [TInlineComponentArray](https://docs.unrealengine.com/4.26/en-US/API/Runtime/Engine/GameFramework/TInlineComponentArray/)
      * @sa [GetComponents](https://docs.unrealengine.com/4.26/en-US/API/Runtime/Engine/GameFramework/AActor/GetComponents/2/)
      */
-    bool InitSensors(AROS2Node* InROS2Node);
+    virtual bool InitSensors(AROS2Node* InROS2Node);
 
     /**
      * @brief Returns the properties used for network replication, this needs to be overridden by all actor classes with native


### PR DESCRIPTION
* ARRBaseRobot virtual InitSensors(), for custom lidar comps to be built in child classes
* Turn ON Procedural Mesh Component's bUseComplexAsSimpleCollision, so it could be line-traced with FCollisionQueryParams::[bTraceComplex](https://github.com/rapyuta-robotics/RapyutaSimulationPlugins/blob/devel/Source/RapyutaSimulationPlugins/Private/Sensors/RR2DLidarComponent.cpp#L67) for lidar detection