### PR TITLE
ServerSpawnEntity: adjust location but always spawn

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
@@ -320,7 +320,8 @@ AActor* ASimulationState::ServerSpawnEntity(const FROSSpawnEntityReq& InROSSpawn
     }
 
     // SpawnActorDeferred to set parameters beforehand
-    AActor* newEntity = GetWorld()->SpawnActorDeferred<AActor>(InEntityClass, InEntityTransform);
+    AActor* newEntity = GetWorld()->SpawnActorDeferred<AActor>(
+        InEntityClass, InEntityTransform, nullptr, nullptr, ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn);
     if (newEntity == nullptr)
     {
         return nullptr;

--- a/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
@@ -320,6 +320,8 @@ AActor* ASimulationState::ServerSpawnEntity(const FROSSpawnEntityReq& InROSSpawn
     }
 
     // SpawnActorDeferred to set parameters beforehand
+    // Using AdjustIfPossibleButAlwaysSpawn, the actual entity's transform could be different from one specified in SpawnEntity,
+    // thus we may need to inform ros side to get synchronized with it
     AActor* newEntity = GetWorld()->SpawnActorDeferred<AActor>(
         InEntityClass, InEntityTransform, nullptr, nullptr, ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn);
     if (newEntity == nullptr)


### PR DESCRIPTION
In practice, robots may not spawn frequently because of obstacles, just add the flag to always spawn