### PR TITLE
Warehouse + DataSynth utils

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
@@ -210,36 +210,20 @@ void URRActorCommon::OnStartSim()
 
 void URRActorCommon::SetupEnvironment()
 {
-    // Here, we initialize artifacts that utilized play resources
     UWorld* currentWorld = GetWorld();
     checkf(currentWorld, TEXT("[URRActorCommon::SetupEnvironment] Failed fetching Game World"));
 
-    // Fetch Main background environment
-    if (!MainEnvironment)
-    {
-        MainEnvironment = URRUObjectUtils::FindEnvironmentActor(currentWorld);
-        // Not all maps has MainEnvironment setup
-    }
+    // By default, these just reference GameState's floor & wall but could be overridable in child class setup
+    SceneFloor = GameState->MainFloor;
+    SceneWall = GameState->MainWall;
 
-    if (!MainFloor)
-    {
-        MainFloor = URRUObjectUtils::FindFloorActor(currentWorld);
-        // Not all maps has MainFloor setup
-    }
-
-    if (!MainWall)
-    {
-        MainWall = URRUObjectUtils::FindWallActor(currentWorld);
-        // Not all maps has MainWall setup
-    }
-
-    // Spawn MainCamera
-    MainCamera =
+    // Spawn Scene main camera
+    SceneCamera =
         Cast<ARRCamera>(URRUObjectUtils::SpawnSimActor(GetWorld(),
                                                        SceneInstanceId,
                                                        ARRCamera::StaticClass(),
                                                        TEXT("RapyutaCamera"),
-                                                       FString::Printf(TEXT("%d_MainCamera"), SceneInstanceId),
+                                                       FString::Printf(TEXT("%d_SceneCamera"), SceneInstanceId),
                                                        FTransform(SceneInstanceLocation),
                                                        ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn));
 }
@@ -251,23 +235,13 @@ bool URRActorCommon::HasInitialized(bool bIsLogged) const
         return true;
     }
 
-    if (!MainCamera)
+    if (!SceneCamera)
     {
         if (bIsLogged)
         {
-            UE_LOG(LogRapyutaCore, Display, TEXT("[URRActorCommon]:: MainCamera is NULL!"))
+            UE_LOG(LogRapyutaCore, Display, TEXT("[URRActorCommon]:: SceneCamera is NULL!"))
         }
         return false;
     }
     return true;
-}
-
-void URRActorCommon::MoveEnvironmentToSceneInstance(int8 InSceneInstanceId)
-{
-    if (IsValid(MainEnvironment))
-    {
-        const FVector currentEnvLocation = MainEnvironment->GetActorLocation();
-        const FVector sceneInstanceLocation = URRCoreUtils::GetSceneInstanceLocation(InSceneInstanceId);
-        MainEnvironment->SetActorLocation(FVector(sceneInstanceLocation.X, sceneInstanceLocation.Y, currentEnvLocation.Z));
-    }
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
@@ -10,6 +10,7 @@
 #include "Core/RRGameMode.h"
 #include "Core/RRGameSingleton.h"
 #include "Core/RRGameState.h"
+#include "Core/RRMeshActor.h"
 #include "Core/RRPlayerController.h"
 #include "Core/RRSceneDirector.h"
 #include "Core/RRThreadUtils.h"
@@ -64,6 +65,24 @@ bool URRSceneInstance::IsValid(bool bIsLogged) const
     return true;
 }
 
+// ===================================================================================================================================
+// [FRRHomoMeshEntityGroup] --
+//
+FString FRRHomoMeshEntityGroup::GetGroupModelName() const
+{
+    const int32 num = Num();
+    return (num == 1) ? Entities[0]->EntityModelName
+         : (num > 1)  ? FString::Printf(TEXT("Merged%d_%s"), num, *Entities[0]->EntityModelName)
+                      : FString();
+}
+
+FString FRRHomoMeshEntityGroup::GetGroupName() const
+{
+    const int32 num = Num();
+    return (num == 1) ? Entities[0]->GetName()
+         : (num > 1)  ? FString::Printf(TEXT("Merged%d_%s"), num, *Entities[0]->GetName())
+                      : FString();
+}
 // ===================================================================================================================================
 // [FRRActorSpawnInfo] --
 //
@@ -142,6 +161,7 @@ void FRRActorSpawnInfo::operator()(const FString& InEntityModelName,
 //
 std::once_flag URRActorCommon::OnceFlag;
 uint64 URRActorCommon::SLatestSceneId = 0;
+TArray<int32> URRActorCommon::StaticCustomDepthStencilList;
 // This is used as a map due to the unequivalence of element order with [ARRGameState::SceneInstanceList]
 TMap<int8, URRActorCommon*> URRActorCommon::SActorCommonList;
 URRActorCommon* URRActorCommon::GetActorCommon(int8 InSceneInstanceId, UClass* InActorCommonClass, UObject* InOuter)

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
@@ -74,6 +74,7 @@ FRRActorSpawnInfo::FRRActorSpawnInfo()
     bIsPhysicsEnabled = true;
     bIsCollisionEnabled = true;
     bIsSelfCollision = false;
+    bIsOverlapEventEnabled = false;
     bIsDataSynthEntity = false;
 }
 
@@ -85,7 +86,8 @@ FRRActorSpawnInfo::FRRActorSpawnInfo(const FString& InEntityModelName,
                                      const TArray<FString>& InMaterialNameList,
                                      bool bInIsStationary,
                                      bool bInIsPhysicsEnabled,
-                                     bool bInIsCollisionEnabled)
+                                     bool bInIsCollisionEnabled,
+                                     bool bInIsOverlapEventEnabled)
     : EntityModelName(InEntityModelName),
       UniqueName(InUniqueName),
       ActorTransform(InActorTransform),
@@ -94,7 +96,8 @@ FRRActorSpawnInfo::FRRActorSpawnInfo(const FString& InEntityModelName,
       MaterialNameList(InMaterialNameList),
       bIsStationary(bInIsStationary),
       bIsPhysicsEnabled(bInIsPhysicsEnabled),
-      bIsCollisionEnabled(bInIsCollisionEnabled)
+      bIsCollisionEnabled(bInIsCollisionEnabled),
+      bIsOverlapEventEnabled(bInIsOverlapEventEnabled)
 {
     bIsTickEnabled = false;
     bIsSelfCollision = false;
@@ -109,7 +112,8 @@ void FRRActorSpawnInfo::operator()(const FString& InEntityModelName,
                                    const TArray<FString>& InMaterialNameList,
                                    bool bInIsStationary,
                                    bool bInIsPhysicsEnabled,
-                                   bool bInIsCollisionEnabled)
+                                   bool bInIsCollisionEnabled,
+                                   bool bInIsOverlapEventEnabled)
 {
     EntityModelName = InEntityModelName;
     UniqueName = InUniqueName;
@@ -127,6 +131,7 @@ void FRRActorSpawnInfo::operator()(const FString& InEntityModelName,
     bIsStationary = bInIsStationary;
     bIsPhysicsEnabled = bInIsPhysicsEnabled;
     bIsCollisionEnabled = bInIsCollisionEnabled;
+    bIsOverlapEventEnabled = bInIsOverlapEventEnabled;
     bIsTickEnabled = false;
     bIsSelfCollision = false;
     bIsDataSynthEntity = false;

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCamera.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCamera.cpp
@@ -67,6 +67,7 @@ void ARRCamera::RandomizePose(bool bIsRandomLocationOnly)
 
 float ARRCamera::GetDistanceToFloor() const
 {
-    check(IsValid(ActorCommon->MainFloor));
-    return FVector::Dist(CameraComponent->GetComponentLocation(), ActorCommon->MainFloor->GetActorLocation());
+    return ActorCommon->SceneFloor
+             ? FVector::Dist(CameraComponent->GetComponentLocation(), ActorCommon->SceneFloor->GetActorLocation())
+             : 0.f;
 };

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCamera.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCamera.cpp
@@ -34,13 +34,18 @@ bool ARRCamera::Initialize()
     {
         return false;
     }
-    CameraComponent->FieldOfView = URRMathUtils::GetRandomFloatInRange(CameraProperties.HFoVRangeInDegree);
+    RandomizeFoV();
     return true;
 }
 
-void ARRCamera::LookAt(const FVector& InTargetLocation)
+void ARRCamera::LookAt(const FVector& InTargetLocation, bool bMoveToNearTarget)
 {
-    CameraComponent->SetWorldRotation((InTargetLocation - GetActorLocation()).ToOrientationQuat());
+    if (bMoveToNearTarget)
+    {
+        SetActorLocation(URRMathUtils::GetRandomSphericalPosition(
+            InTargetLocation, CameraProperties.DistanceRangeInCm, CameraProperties.HeightRangeInCm));
+    }
+    SetActorRotation((InTargetLocation - GetActorLocation()).ToOrientationQuat());
 }
 
 void ARRCamera::RandomizeFoV()
@@ -48,11 +53,10 @@ void ARRCamera::RandomizeFoV()
     CameraComponent->FieldOfView = URRMathUtils::GetRandomFloatInRange(CameraProperties.HFoVRangeInDegree);
 }
 
-void ARRCamera::RandomizePose(bool bIsRandomLocationOnly)
+void ARRCamera::RandomizePose(const FVector& InBaseLocation, bool bIsRandomLocationOnly)
 {
-    const FVector sceneInstanceLocation = URRCoreUtils::GetSceneInstanceLocation(SceneInstanceId);
     const FVector randomLocation = URRMathUtils::GetRandomSphericalPosition(
-        sceneInstanceLocation, CameraProperties.DistanceRangeInCm, CameraProperties.HeightRangeInCm);
+        InBaseLocation, CameraProperties.DistanceRangeInCm, CameraProperties.HeightRangeInCm);
 
     if (bIsRandomLocationOnly)
     {
@@ -70,4 +74,4 @@ float ARRCamera::GetDistanceToFloor() const
     return ActorCommon->SceneFloor
              ? FVector::Dist(CameraComponent->GetComponentLocation(), ActorCommon->SceneFloor->GetActorLocation())
              : 0.f;
-};
+}

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
@@ -339,7 +339,7 @@ UTextureLightProfile* URRCoreUtils::LoadIESProfile(const FString& InFullFilePath
     {
         UE_LOG(LogRapyutaCore,
                Error,
-               TEXT("[URRCoreUtils::LoadIESProfile] IESConverter failed creating buffer from imdage loaded from [%s]"),
+               TEXT("[URRCoreUtils::LoadIESProfile] IESConverter failed creating buffer from image loaded from [%s]"),
                *InFullFilePath);
         return nullptr;
     }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
@@ -50,6 +50,7 @@ void URRCoreUtils::LoadImageWrapperModule()
     {
         verify(SImageWrapperModule);
         SImageWrappers.Add(ERRFileType::IMAGE_JPG, SImageWrapperModule->CreateImageWrapper(EImageFormat::JPEG));
+        SImageWrappers.Add(ERRFileType::IMAGE_GRAYSCALE_JPG, SImageWrapperModule->CreateImageWrapper(EImageFormat::GrayscaleJPEG));
         SImageWrappers.Add(ERRFileType::IMAGE_PNG, SImageWrapperModule->CreateImageWrapper(EImageFormat::PNG));
         SImageWrappers.Add(ERRFileType::IMAGE_EXR, SImageWrapperModule->CreateImageWrapper(EImageFormat::EXR));
     }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
@@ -138,6 +138,11 @@ bool URRCoreUtils::HasEnoughDiskSpace(const FString& InPath, uint64 InRequiredMe
     return bEnoughMemory;
 }
 
+bool URRCoreUtils::IsSimProfiling()
+{
+    return URRGameSingleton::Get()->BSIM_PROFILING;
+}
+
 bool URRCoreUtils::ShutDownSim(const UObject* InContextObject, uint64 InSimCompletionTimeoutInSecs)
 {
     // END ALL SCENE INSTANCES' OPERATIONS --

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Engine/GameViewportClient.h"
 #include "HAL/PlatformProcess.h"
+#include "IESConverter.h"
 #include "ImageUtils.h"
 
 // RapyutaSimulationPlugins
@@ -22,6 +23,13 @@
 
 IImageWrapperModule* URRCoreUtils::SImageWrapperModule = nullptr;
 TMap<ERRFileType, TSharedPtr<IImageWrapper>> URRCoreUtils::SImageWrappers;
+FRRLightProfileData URRCoreUtils::SLightProfileData;
+TFunction<void(uint8*, const FUpdateTextureRegion2D*)> URRCoreUtils::CleanupLightProfileData =
+    [](uint8*, const FUpdateTextureRegion2D*)
+{
+    FMemory::Free(SLightProfileData.ImageData);
+    SLightProfileData.ImageData = nullptr;
+};
 
 FString URRCoreUtils::GetFileTypeFilter(const ERRFileType InFileType)
 {
@@ -304,6 +312,120 @@ bool URRCoreUtils::LoadImagesFromFolder(const FString& InImageFolderPath,
     if (!bResult && bIsLogged)
     {
         UE_LOG(LogRapyutaCore, Error, TEXT("Failed to load all images from [%s] into textures!"), *InImageFolderPath);
+    }
+
+    return bResult;
+}
+
+// Ref: DatasmithRuntime::GetTextureDataForIes() & CreateIESTexture()
+UTextureLightProfile* URRCoreUtils::LoadIESProfile(const FString& InFullFilePath, const FString& InLightProfileName)
+{
+    TArray<uint8> buffer;
+    if (!(FFileHelper::LoadFileToArray(buffer, *InFullFilePath) && buffer.Num() > 0))
+    {
+        UE_LOG(LogRapyutaCore, Error, TEXT("[URRCoreUtils::LoadIESProfile] Failed loading file to array [%s]"), *InFullFilePath);
+        return nullptr;
+    }
+
+    // checks for .IES extension to avoid wasting loading large assets just to reject them during header parsing
+    FIESConverter iesConverter(buffer.GetData(), buffer.Num());
+    if (false == iesConverter.IsValid())
+    {
+        UE_LOG(LogRapyutaCore,
+               Error,
+               TEXT("[URRCoreUtils::LoadIESProfile] IESConverter failed creating buffer from imdage loaded from [%s]"),
+               *InFullFilePath);
+        return nullptr;
+    }
+
+    // Fille loaded data into [SLightProfileData]
+    SLightProfileData.Width = iesConverter.GetWidth();
+    SLightProfileData.Height = iesConverter.GetHeight();
+    SLightProfileData.Brightness = iesConverter.GetBrightness();
+    SLightProfileData.BytesPerPixel = 8;    // RGBA16F
+    SLightProfileData.Pitch = SLightProfileData.Width * SLightProfileData.BytesPerPixel;
+    SLightProfileData.TextureMultiplier = iesConverter.GetMultiplier();
+    const TArray<uint8>& rawData = iesConverter.GetRawData();
+    SLightProfileData.ImageData = (uint8*)FMemory::Malloc(rawData.Num() * sizeof(uint8), 0x20);
+    FMemory::Memcpy(SLightProfileData.ImageData, rawData.GetData(), rawData.Num() * sizeof(uint8));
+    ensure(SLightProfileData.ImageData);
+
+    // [SLightProfileData] -> [lightProfile]
+    UTextureLightProfile* lightProfile = NewObject<UTextureLightProfile>(GetTransientPackage(), *InLightProfileName, RF_Transient);
+    if (!lightProfile)
+    {
+        return nullptr;
+    }
+
+#if WITH_EDITORONLY_DATA
+    FAssetImportInfo importInfo;
+    importInfo.Insert(FAssetImportInfo::FSourceFile(InLightProfileName));
+    lightProfile->AssetImportData->SourceData = MoveTemp(importInfo);
+
+    lightProfile->Source.Init(SLightProfileData.Width,
+                              SLightProfileData.Height,
+                              /*NumSlices=*/1,
+                              1,
+                              TSF_RGBA16F,
+                              SLightProfileData.ImageData);
+    CleanupLightProfileData(nullptr, nullptr);
+#endif
+
+    lightProfile->LODGroup = TEXTUREGROUP_IESLightProfile;
+    lightProfile->AddressX = TA_Clamp;
+    lightProfile->AddressY = TA_Clamp;
+    lightProfile->CompressionSettings = TC_HDR;
+#if WITH_EDITORONLY_DATA
+    lightProfile->MipGenSettings = TMGS_NoMipmaps;
+#endif
+    lightProfile->Brightness = SLightProfileData.Brightness;
+    lightProfile->TextureMultiplier = SLightProfileData.TextureMultiplier;
+
+    // Update the texture with these new settings
+    lightProfile->UpdateResource();
+
+#if !WITH_EDITOR
+    SLightProfileData.Region = FUpdateTextureRegion2D(0, 0, 0, 0, SLightProfileData.Width, SLightProfileData.Height);
+    lightProfile->UpdateTextureRegions(0,
+                                       1,
+                                       &SLightProfileData.Region,
+                                       SLightProfileData.Pitch,
+                                       SLightProfileData.BytesPerPixel,
+                                       SLightProfileData.ImageData,
+                                       CleanupLightProfileData);
+#endif
+    return lightProfile;
+}
+
+bool URRCoreUtils::LoadIESProfilesFromFolder(const FString& InFolderPath,
+                                             TArray<UTextureLightProfile*>& OutLightProfileList,
+                                             bool bIsLogged)
+{
+    TArray<FString> filePaths;
+    bool bResult = LoadFullFilePaths(InFolderPath, filePaths, {ERRFileType::LIGHT_PROFILE_IES});
+    if (bResult)
+    {
+        for (const auto& iesProfilePath : filePaths)
+        {
+            // FPaths::GetCleanFilename() could be used but rather not due to being more expensive.
+            // Also, InFolderPath could be single or compound relative path, which must be unique to be light profile name.
+            FString&& iesProfileName = iesProfilePath.RightChop(InFolderPath.Len());
+            if (UTextureLightProfile* iesProfile = LoadIESProfile(iesProfilePath, iesProfileName))
+            {
+                OutLightProfileList.Add(iesProfile);
+            }
+            else
+            {
+                // Continue the loading regardless of some being failed.
+                bResult = false;
+                UE_LOG(LogRapyutaCore, Error, TEXT("Failed to load ies profile to light texture [%s]"), *iesProfilePath);
+            }
+        }
+    }
+
+    if (!bResult && bIsLogged)
+    {
+        UE_LOG(LogRapyutaCore, Error, TEXT("Failed to load all ies profiles from [%s] into light textures!"), *InFolderPath);
     }
 
     return bResult;

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -18,12 +18,19 @@ TMap<ERRResourceDataType, TArray<const TCHAR*>> URRGameSingleton::SASSET_OWNING_
     {ERRResourceDataType::UE_MATERIAL, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
 };
 
-URRGameSingleton::URRGameSingleton(){
-    UE_LOG(LogRapyutaCore, Display, TEXT("[RR GAME SINGLETON] INSTANTIATED! ======================"))}
+URRGameSingleton::URRGameSingleton()
+{
+    UE_LOG(LogRapyutaCore, Display, TEXT("[RR GAME SINGLETON] INSTANTIATED! ======================"));
+}
 
 URRGameSingleton::~URRGameSingleton()
 {
     // AssetDataList.Empty();
+}
+
+void URRGameSingleton::PrintSimConfig() const
+{
+    UE_LOG(LogRapyutaCore, Display, TEXT("- SIM PROFILING: %d"), BSIM_PROFILING);
 }
 
 URRGameSingleton* URRGameSingleton::Get()

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -16,6 +16,7 @@ TMap<ERRResourceDataType, TArray<const TCHAR*>> URRGameSingleton::SASSET_OWNING_
     {ERRResourceDataType::UE_SKELETON, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
     {ERRResourceDataType::UE_PHYSICS_ASSET, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
     {ERRResourceDataType::UE_MATERIAL, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
+    {ERRResourceDataType::UE_TEXTURE, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
 };
 
 URRGameSingleton::URRGameSingleton()
@@ -103,8 +104,11 @@ bool URRGameSingleton::InitializeResources()
     verify(RequestResourcesLoading(dataType));
 
     // [TEXTURE] --
-    // Textures are only externally loaded for now
-    GetSimResourceInfo(ERRResourceDataType::UE_TEXTURE).HasBeenAllLoaded = true;
+    dataType = ERRResourceDataType::UE_TEXTURE;
+    CollateAssetsInfo<UTexture>(dataType, FOLDER_PATH_ASSET_TEXTURES);
+    // Request Texture resource async loading
+    GetSimResourceInfo(dataType).HasBeenAllLoaded = false;
+    verify(RequestResourcesLoading(dataType));
 
     // [BODY SETUP] --
     // Body setups are dynamically created in runtime

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
@@ -14,6 +14,7 @@
 #include "Core/RRCoreUtils.h"
 #include "Core/RRGameInstance.h"
 #include "Core/RRMathUtils.h"
+#include "Core/RRMeshActor.h"
 #include "Core/RRPlayerController.h"
 #include "Core/RRROS2GameMode.h"
 #include "Core/RRSceneDirector.h"
@@ -35,6 +36,7 @@ void ARRGameState::PrintSimConfig() const
            TEXT("SIM_OUTPUTS_BASE_FOLDER_NAME: %s -> %s"),
            *SIM_OUTPUTS_BASE_FOLDER_NAME,
            *GetSimOutputsBaseFolderPath());
+
     UE_LOG(LogRapyutaCore, Display, TEXT("OPERATION_BATCHES_NUM: %d"), OPERATION_BATCHES_NUM);
     UE_LOG(LogRapyutaCore, Display, TEXT("ENTITY_BOUNDING_BOX_VERTEX_NORMALS:"));
     for (const auto& vertexNormal : ENTITY_BOUNDING_BOX_VERTEX_NORMALS)
@@ -65,8 +67,8 @@ void ARRGameState::StartSim()
     UE_LOG(LogRapyutaCore, Display, TEXT("MAX SPLIT SCREEN PLAYERS: %d"), maxSplitscreenPlayers);
     verify(SCENE_INSTANCES_NUM <= maxSplitscreenPlayers);
 
-    // 0- Fetch static-env actors
-    FetchEnvironmentActors();
+    // 0- Stream level & Fetch static-env actors
+    SetupEnvironment();
 
     for (int8 i = 0; i < SCENE_INSTANCES_NUM; ++i)
     {
@@ -87,8 +89,14 @@ void ARRGameState::StartSim()
     }
 }
 
-void ARRGameState::FetchEnvironmentActors()
+void ARRGameState::SetupEnvironment()
 {
+    FetchEnvStaticActors();
+}
+
+void ARRGameState::FetchEnvStaticActors()
+{
+    // Fetch env actors
     UWorld* currentWorld = GetWorld();
     checkf(currentWorld, TEXT("[ARRGameState::SetupEnvironment] Failed fetching Game World"));
 
@@ -103,28 +111,7 @@ void ARRGameState::FetchEnvironmentActors()
     // Not all maps has MainWall setup
 
     MainLights = URRUObjectUtils::FindActorListByType<ALight>(currentWorld);
-    check(MainLights.Num() > 0);
-
-    MainStaticMeshActors = URRUObjectUtils::FindActorListByType<AStaticMeshActor>(currentWorld);
-    if ((MainStaticMeshActors.Num() > 0) && (nullptr == MainEnvironment))
-    {
-        // Set the first static mesh actor as [MainEnvironment]
-        MainEnvironment = MainStaticMeshActors[0];
-        // & let others attach to it
-        for (auto i = 1; i < MainStaticMeshActors.Num(); ++i)
-        {
-            MainStaticMeshActors[i]->AttachToActor(MainEnvironment, FAttachmentTransformRules::KeepWorldTransform);
-        }
-        for (auto& light : MainLights)
-        {
-            light->AttachToActor(MainEnvironment, FAttachmentTransformRules::KeepWorldTransform);
-        }
-    }
-
-    if (MainEnvironment)
-    {
-        MainEnvOriginalLocation = MainEnvironment->GetActorLocation();
-    }
+    // Not all maps has MainLights setup
 }
 
 void ARRGameState::CreateSceneInstance(int8 InSceneInstanceId)
@@ -246,11 +233,14 @@ bool ARRGameState::HaveAllSceneInstancesCompleted() const
 
 void ARRGameState::MoveEnvironmentToSceneInstance(int8 InSceneInstanceId)
 {
-    if (IsValid(MainEnvironment))
+    if (InSceneInstanceId != LastSceneInstanceId)
     {
-        const FVector defaultSceneInstanceLocation = URRCoreUtils::GetSceneInstanceLocation(0);
-        const FVector sceneInstanceLocation = URRCoreUtils::GetSceneInstanceLocation(InSceneInstanceId);
-        MainEnvironment->SetActorLocation(MainEnvOriginalLocation + sceneInstanceLocation - defaultSceneInstanceLocation);
+        if (IsValid(MainEnvironment))
+        {
+            MainEnvironment->AddActorWorldOffset(URRCoreUtils::GetSceneInstanceLocation(InSceneInstanceId) -
+                                                 URRCoreUtils::GetSceneInstanceLocation(LastSceneInstanceId));
+        }
+        LastSceneInstanceId = InSceneInstanceId;
     }
 }
 
@@ -302,25 +292,11 @@ void ARRGameState::EndPlay(const EEndPlayReason::Type EndPlayReason)
     Super::EndPlay(EndPlayReason);
 }
 
-void ARRGameState::Tick(float DeltaTime)
+void ARRGameState::SetAllEntitiesActivated(bool bIsActivated)
 {
-    Super::Tick(DeltaTime);
-
-    if (!HasInitialized())
+    for (auto& entity : AllDynamicMeshEntities)
     {
-        return;
-    }
-
-    // PROFILING --
-    // [OnTick()] is virtual, and only runs upon GameState having been already initialized!
-    OnTick(DeltaTime);
-}
-
-void ARRGameState::OnTick(float DeltaTime)
-{
-    for (auto& sceneInstance : SceneInstanceList)
-    {
-        sceneInstance->ActorCommon->OnTick(DeltaTime);
+        entity->SetActivated(bIsActivated);
     }
 }
 
@@ -352,10 +328,7 @@ ARRMeshActor* ARRGameState::FindEntityByModel(const FString& InEntityModelName, 
     return resultEntity;
 }
 
-void ARRGameState::SetAllEntitiesActivated(bool bIsActivated)
+void ARRGameState::AddEntity(ARRMeshActor* InEntity)
 {
-    for (auto& entity : AllDynamicMeshEntities)
-    {
-        entity->SetActivated(bIsActivated);
-    }
+    AllDynamicMeshEntities.AddUnique(InEntity);
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
@@ -27,6 +27,7 @@ ARRGameState::ARRGameState()
 
 void ARRGameState::PrintSimConfig() const
 {
+    UE_LOG(LogRapyutaCore, Log, TEXT("GAME STATE CONFIG -----------------------------"));
     UE_LOG(LogRapyutaCore, Display, TEXT("SCENE_INSTANCES_NUM: %d"), SCENE_INSTANCES_NUM);
     UE_LOG(LogRapyutaCore, Display, TEXT("SCENE_INSTANCES_DISTANCE_INTERVAL: %f(cm)"), SCENE_INSTANCES_DISTANCE_INTERVAL);
     UE_LOG(LogRapyutaCore,
@@ -49,7 +50,7 @@ void ARRGameState::StartSim()
 {
     UE_LOG(LogRapyutaCore, Display, TEXT("[ARRGameState::StartSim() with Num of SceneInstances: %d]"), SCENE_INSTANCES_NUM);
 
-    // TBU: URRGameSingleton::Get()->PrintSimConfig();
+    URRGameSingleton::Get()->PrintSimConfig();
     PrintSimConfig();
 
     GameMode = URRCoreUtils::GetGameMode<ARRGameMode>(this);

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRPlayerController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRPlayerController.cpp
@@ -55,6 +55,7 @@ bool ARRPlayerController::Initialize()
 
     SceneCamera = ActorCommon->SceneCamera;
     check(SceneCamera);
+    Possess(SceneCamera);
 
     // Not all maps has GlobalPostProcessVolume
     MainPostProcessVolume = Cast<APostProcessVolume>(URRUObjectUtils::FindPostProcessVolume(GetWorld()));

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRPlayerController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRPlayerController.cpp
@@ -55,7 +55,10 @@ bool ARRPlayerController::Initialize()
 
     SceneCamera = ActorCommon->SceneCamera;
     check(SceneCamera);
-    Possess(SceneCamera);
+    if (GameMode->IsDataSynthSimType())
+    {
+        Possess(SceneCamera);
+    }
 
     // Not all maps has GlobalPostProcessVolume
     MainPostProcessVolume = Cast<APostProcessVolume>(URRUObjectUtils::FindPostProcessVolume(GetWorld()));

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRPlayerController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRPlayerController.cpp
@@ -53,8 +53,8 @@ bool ARRPlayerController::Initialize()
     check(ActorCommon);
     check(ActorCommon->SceneInstanceId == SceneInstanceId);
 
-    MainCamera = ActorCommon->MainCamera;
-    check(MainCamera);
+    SceneCamera = ActorCommon->SceneCamera;
+    check(SceneCamera);
 
     // Not all maps has GlobalPostProcessVolume
     MainPostProcessVolume = Cast<APostProcessVolume>(URRUObjectUtils::FindPostProcessVolume(GetWorld()));
@@ -78,11 +78,11 @@ bool ARRPlayerController::HasInitialized(bool bIsLogged) const
         return false;
     }
 
-    if (!MainCamera)
+    if (!SceneCamera)
     {
         if (bIsLogged)
         {
-            UE_LOG(LogRapyutaCore, Warning, TEXT("[ARRPlayerController]:: MainCamera is NULL!"));
+            UE_LOG(LogRapyutaCore, Warning, TEXT("[ARRPlayerController]:: SceneCamera is NULL!"));
         }
         return false;
     }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
@@ -34,13 +34,7 @@ URRProceduralMeshComponent::URRProceduralMeshComponent(const FObjectInitializer&
 
 void URRProceduralMeshComponent::Initialize(bool bIsStaticBody, bool bInIsPhysicsEnabled)
 {
-    // CustomDepthStencilValue
-    ARRMeshActor* ownerActor = CastChecked<ARRMeshActor>(GetOwner());
-    if (ownerActor->GameMode->IsDataSynthSimType() && ownerActor->IsDataSynthEntity())
-    {
-        verify(IsValid(ownerActor->ActorCommon));
-        SetCustomDepthStencilValue(ownerActor->ActorCommon->GenerateUniqueDepthStencilValue());
-    }
+    // CustomDepthStencil will be actively set by stakeholders or ARRMeshActor if needs be
 }
 
 bool URRProceduralMeshComponent::InitializeMesh(const FString& InMeshFileName)
@@ -132,10 +126,16 @@ bool URRProceduralMeshComponent::CreateMeshBody(const FRRMeshData& InBodyMeshDat
         // (NOTE) This also invoke UpdateCollision() but without collision info yet
         CreateMeshSection(node.Meshes);
     }
-    for (auto matIndex = 0; matIndex < InBodyMeshData.MaterialInstances.Num(); ++matIndex)
+
+    ARRMeshActor* ownerActor = CastChecked<ARRMeshActor>(GetOwner());
+    if (false == ownerActor->GameMode->IsDataSynthSimType())
     {
-        SetMaterial(matIndex, InBodyMeshData.MaterialInstances[matIndex]);
+        for (auto i = 0; i < InBodyMeshData.MaterialInstances.Num(); ++i)
+        {
+            SetMaterial(i, InBodyMeshData.MaterialInstances[i]);
+        }
     }
+
     // These should have been marked by PMC itself
     // MarkRenderStateDirty();
     // MarkRenderDynamicDataDirty();

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
@@ -400,11 +400,11 @@ void URRProceduralMeshComponent::SetCollisionModeAvailable(bool bIsOn, bool bIsH
     }
 }
 
-void URRProceduralMeshComponent::EnableOverlapping()
+void URRProceduralMeshComponent::EnableOverlapping(bool bOverlapEventEnabled)
 {
     SetSimulatePhysics(false);
     SetCollisionProfileName(TEXT("Overlap"));
     SetCollisionEnabled(ECollisionEnabled::QueryOnly);    // SUPER IMPORTANT!
     SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Overlap);
-    SetGenerateOverlapEvents(true);
+    SetGenerateOverlapEvents(bOverlapEventEnabled);
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
@@ -122,6 +122,18 @@ void ARRSceneDirector::OnDataCollectionPhaseDone(bool bIsFinalDataCollectingPhas
     {
         bIsDataCollecting = false;
     }
+
+    // PROFILING --
+    if (URRCoreUtils::IsSimProfiling())
+    {
+        // Measure the running of the previous data collection
+        UE_LOG(LogRapyutaCore,
+               Log,
+               TEXT("[%d] DATA COLLECTION[%d] DONE - TOOK [%lf] secs!"),
+               SceneInstanceId,
+               bIsFinalDataCollectingPhase ? 2 : 1,
+               URRCoreUtils::GetElapsedTime(DataCollectionTimeStamp));
+    }
 }
 
 void ARRSceneDirector::ResetScene()

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
@@ -82,8 +82,8 @@ bool ARRSceneDirector::InitializeOperation()
     ActorCommon = URRActorCommon::GetActorCommon(SceneInstanceId);
 
     // Camera
-    MainCamera = ActorCommon->MainCamera;
-    verify(MainCamera);
+    SceneCamera = ActorCommon->SceneCamera;
+    verify(SceneCamera);
 
     // PostProcessVolume
     MainPostProcessVolume = Cast<APostProcessVolume>(URRUObjectUtils::FindPostProcessVolume(GetWorld()));

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
@@ -121,18 +121,17 @@ void ARRSceneDirector::OnDataCollectionPhaseDone(bool bIsFinalDataCollectingPhas
     if (bIsFinalDataCollectingPhase)
     {
         bIsDataCollecting = false;
-    }
 
-    // PROFILING --
-    if (URRCoreUtils::IsSimProfiling())
-    {
-        // Measure the running of the previous data collection
-        UE_LOG(LogRapyutaCore,
-               Log,
-               TEXT("[%d] DATA COLLECTION[%d] DONE - TOOK [%lf] secs!"),
-               SceneInstanceId,
-               bIsFinalDataCollectingPhase ? 2 : 1,
-               URRCoreUtils::GetElapsedTime(DataCollectionTimeStamp));
+        // PROFILING --
+        if (URRCoreUtils::IsSimProfiling())
+        {
+            // Measure the running of the previous data collection
+            UE_LOG(LogRapyutaCore,
+                   Log,
+                   TEXT("[%d] DATA COLLECTION DONE - TOOK [%lf] secs!"),
+                   SceneInstanceId,
+                   URRCoreUtils::GetElapsedTime(DataCollectionTimeStamp));
+        }
     }
 }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
@@ -20,22 +20,14 @@ ARRSceneDirector::ARRSceneDirector()
     bIsOperating = false;
 }
 
-void ARRSceneDirector::Tick(float DeltaTime)
-{
-    Super::Tick(DeltaTime);
-    if (!bSceneInitialized)
-    {
-        TryInitializeOperation();
-    }
-}
-
 bool ARRSceneDirector::Initialize()
 {
     if (false == Super::Initialize())
     {
         return false;
     }
-    SetTickEnabled(true);
+    URRCoreUtils::RegisterRepeatedExecution(
+        this, InitializationTimerHandle, [this] { TryInitializeOperation(); }, 0.1f);
 
     // Run [TryInitializeOperation()] until succeeded!
     UE_LOG(LogRapyutaCore, Display, TEXT("[%d:SCENE DIRECTOR]::[%s] TRYING TO INTIALIZE..."), SceneInstanceId, *GetName());
@@ -60,6 +52,7 @@ void ARRSceneDirector::TryInitializeOperation()
                         "OPERATION!============="),
                    SceneInstanceId,
                    elapsedTime);
+            URRCoreUtils::StopRegisteredExecution(GetWorld(), InitializationTimerHandle);
         }
         else
         {
@@ -137,7 +130,8 @@ void ARRSceneDirector::OnDataCollectionPhaseDone(bool bIsFinalDataCollectingPhas
 
 void ARRSceneDirector::ResetScene()
 {
-    GameState->SetAllEntitiesActivated(false);
+    ActorCommon->LatestCustomDepthStencilValue = 0;
+    SceneEntityMaskValueList.Reset();
 }
 
 void ARRSceneDirector::EndSceneInstance()

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
@@ -372,13 +372,13 @@ void URRStaticMeshComponent::SetCollisionModeAvailable(bool bInCollisionEnabled,
     }
 }
 
-void URRStaticMeshComponent::EnableOverlapping()
+void URRStaticMeshComponent::EnableOverlapping(bool bOverlapEventEnabled)
 {
     SetSimulatePhysics(false);
     SetCollisionProfileName(TEXT("Overlap"));
     SetCollisionEnabled(ECollisionEnabled::QueryOnly);    // SUPER IMPORTANT!
     SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Overlap);
-    SetGenerateOverlapEvents(true);
+    SetGenerateOverlapEvents(bOverlapEventEnabled);
 }
 
 // This function is used proprietarily for Generic Link/Joint (Non-Articulation) structure

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
@@ -56,13 +56,7 @@ void URRStaticMeshComponent::Initialize(bool bInIsStationary, bool bInIsPhysicsE
     // Refer to [FBodyInstance::SetInstanceSimulatePhysics()]
     SetSimulatePhysics(bInIsPhysicsEnabled);
 
-    // CustomDepthStencilValue
-    ARRMeshActor* ownerActor = CastChecked<ARRMeshActor>(GetOwner());
-    if (ownerActor->GameMode->IsDataSynthSimType() && ownerActor->IsDataSynthEntity())
-    {
-        verify(IsValid(ownerActor->ActorCommon));
-        SetCustomDepthStencilValue(ownerActor->ActorCommon->GenerateUniqueDepthStencilValue());
-    }
+    // CustomDepthStencil will be actively set by stakeholders or ARRMeshActor if needs be
 }
 
 void URRStaticMeshComponent::SetMesh(UStaticMesh* InStaticMesh)
@@ -318,7 +312,7 @@ void URRStaticMeshComponent::CreateMeshSection(const TArray<FRRMeshNodeData>& In
             const FVertexInstanceID instanceID = OutMeshDescBuilder.AppendInstance(vertexIDs[vIdx]);
             OutMeshDescBuilder.SetInstanceNormal(instanceID, mesh.Normals[vIdx]);
             OutMeshDescBuilder.SetInstanceUV(instanceID, mesh.UVs[vIdx], 0);
-            OutMeshDescBuilder.SetInstanceColor(instanceID, FVector4f(mesh.VertexColors[vIdx]));
+            OutMeshDescBuilder.SetInstanceColor(instanceID, FVector4f(FLinearColor(mesh.VertexColors[vIdx])));
             vertexInsts.Emplace(instanceID);
         }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
@@ -9,6 +9,7 @@
 
 // RapyutaSimulationPlugins
 #include "Core/RRGameSingleton.h"
+#include "Core/RRMeshUtils.h"
 
 // RapyutaSimulationPlugins
 #include "Core/RRActorCommon.h"

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
@@ -275,6 +275,7 @@ FString URRUObjectUtils::GetSegMaskDepthStencilsAsText(ARRMeshActor* InActor)
     return FString::JoinBy(
         depthStencilValueList, TEXT("/"), [](const uint8& InDepthStencilValue) { return FString::FromInt(InDepthStencilValue); });
 }
+
 UMaterialInstanceDynamic* URRUObjectUtils::CreateMeshCompMaterialInstance(UMeshComponent* InMeshComp,
                                                                           int32 InMaterialIndex,
                                                                           const FString& InMaterialInterfaceName)

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
@@ -12,6 +12,101 @@
 #include "Core/RRMathUtils.h"
 #include "Core/RRMeshActor.h"
 
+static TArray<uint8> DATA_SYNTH_CUSTOM_DEPTH_STENCILS = []()
+{
+    TArray<uint8> data = {
+        /*0*/ 0,
+        /*1*/ 13,
+        /*2*/ 22,
+        /*3*/ 28,
+        /*4*/ 34,
+        /*5*/ 38,
+        /*6*/ 42,
+        /*7*/ 46,
+        /*8*/ 49,
+        /*9*/ 53,
+
+        /*10*/ 56,
+        /*11*/ 58,
+        /*12*/ 61,
+        /*13*/ 64,
+        /*14*/ 66,
+        /*15*/ 68,
+        /*16*/ 71,
+        /*17*/ 73,
+        /*18*/ 75,
+        /*19*/ 77,
+
+        /*20*/ 79,
+        /*21*/ 81,
+        /*22*/ 83,
+        /*23*/ 85,
+        /*24*/ 86,
+        /*25*/ 88,
+        /*26*/ 90,
+        /*27*/ 91,
+        /*28*/ 93,
+        /*29*/ 95,
+
+        /*30*/ 96,
+        /*31*/ 98,
+        /*32*/ 99,
+        /*33*/ 101,
+        /*34*/ 102,
+        /*35*/ 103,
+        /*36*/ 105,
+        /*37*/ 106,
+        /*38*/ 107,
+        /*39*/ 109,
+
+        /*40*/ 110,
+        /*41*/ 111,
+        /*42*/ 113,
+        /*43*/ 114,
+        /*44*/ 115,
+        /*45*/ 116,
+        /*46*/ 118,
+        /*47*/ 119,
+        /*48*/ 120,
+        /*49*/ 121,
+
+        /*50*/ 122,
+        /*51*/ 123,
+        /*52*/ 124,
+        /*53*/ 126,
+        /*54*/ 127,
+        /*55*/ 128,
+        /*56*/ 129,
+        /*57*/ 130,
+        /*58*/ 131,
+        /*59*/ 132,
+
+        /*60*/ 133,
+        /*61*/ 134,
+        /*62*/ 135,
+        /*63*/ 136,
+        /*64*/ 137,
+        /*65*/ 138,
+        /*66*/ 139,
+        /*67*/ 140,
+        /*68*/ 141,
+        /*69*/ 142,
+
+        /*70*/ 143,
+        /*71*/ 144,
+        /*72*/ 145,
+        /*73*/ 146,
+        /*74*/ 147,
+        /*75*/ 148,
+    };
+
+    for (auto i = 76; i <= 255; ++i)
+    {
+        data.Add(0);
+    }
+    return data;
+}();
+
 void URRUObjectUtils::SetupActorTick(AActor* InActor, bool bIsTickEnabled, float InTickInterval)
 {
     // Tick if not required could be disabled to improve performance
@@ -167,17 +262,19 @@ ARRBaseActor* URRUObjectUtils::SpawnSimActor(UWorld* InWorld,
 
 void URRUObjectUtils::GetActorCenterAndBoundingBoxVertices(const AActor* InActor,
                                                            const AActor* InBaseActor,
-                                                           TArray<FVector>& OutCenterAndVertices,
+                                                           TArray<FVector>* OutCenterAndVertices3D,
                                                            bool bInIncludeNonColliding)
 {
+    OutCenterAndVertices3D->Reset();
     ARRGameState* gameState = URRCoreUtils::GetGameState<ARRGameState>(InActor);
 
     // [InActor]'s Local bounding box
+    //NOTE: For a single [InActor], its EXTENT would be the same as using [InActor->GetComponentsBoundingBox()]
     FVector centerLocal, extentsLocal;
     FBox actorLocalBox = InActor->CalculateComponentsBoundingBoxInLocalSpace(bInIncludeNonColliding);
     actorLocalBox.GetCenterAndExtents(centerLocal, extentsLocal);
 
-    // [InActor]'s global bounding box with rotation (in BaseActor frame or World frame)
+    // [InActor]'s global oriented bounding box with rotation (in BaseActor frame or World frame)
     // Reference : DrawDebugBox()
     // (snote) The exact order of points is important. Consult with Robot Research team before adjusting.
 
@@ -185,20 +282,17 @@ void URRUObjectUtils::GetActorCenterAndBoundingBoxVertices(const AActor* InActor
     // UnrealEngine/Engine/Plugins/2D/Paper2D/Source/Paper2D/Private/PaperSpriteComponent.cpp:179
     const FTransform baseTransform =
         InBaseActor ? InActor->GetActorTransform().GetRelativeTransform(InBaseActor->GetTransform()) : InActor->GetTransform();
-    const FVector center = baseTransform.TransformPosition(centerLocal);
-    OutCenterAndVertices.Emplace(center);
+    const FVector centerBase = baseTransform.TransformPosition(centerLocal);
+    OutCenterAndVertices3D->Emplace(centerBase);
 
     // [InActor]'s global Rotation (in BaseActor frame or World frame)
     const FQuat& actorQuat = InBaseActor ? URRUObjectUtils::GetRelativeQuatFrom(InActor, InBaseActor) : InActor->GetActorQuat();
 
     // Calculate global vertices as : [center] + Rotated [ExtentsLocal]
-    for (auto i = 0; i < 8; ++i)
+    for (auto i = 0; i < gameState->ENTITY_BOUNDING_BOX_VERTEX_NORMALS.Num(); ++i)
     {
-        const FVector& vertexNormal = gameState->ENTITY_BOUNDING_BOX_VERTEX_NORMALS[i];
-        OutCenterAndVertices.Emplace(center +
-                                     actorQuat.RotateVector(FVector((0.f == vertexNormal.X) ? -extentsLocal.X : extentsLocal.X,
-                                                                    (0.f == vertexNormal.Y) ? -extentsLocal.Y : extentsLocal.Y,
-                                                                    (0.f == vertexNormal.Z) ? -extentsLocal.Z : extentsLocal.Z)));
+        OutCenterAndVertices3D->Emplace(
+            centerBase + actorQuat.RotateVector(GetDirectedExtent(gameState->GetEntityBBVertexNormal(i), extentsLocal)));
     }
 }
 
@@ -241,7 +335,6 @@ bool URRUObjectUtils::GetPhysicsActorHandles(FBodyInstance* InBody1,
     OutActorRef2 = actorRef2;
     return true;
 }
-
 void URRUObjectUtils::SetHomoLinearConstraintMotion(FConstraintInstance* InCI, const ELinearConstraintMotion InHomoLinearMotion)
 {
     const bool bEnabled = (InHomoLinearMotion != ELinearConstraintMotion::LCM_Locked);
@@ -262,14 +355,23 @@ void URRUObjectUtils::SetHomoAngularConstraintMotion(FConstraintInstance* InCI, 
     InCI->SetAngularTwistMotion(InHomoAngularMotion);
 }
 
-FString URRUObjectUtils::GetSegMaskDepthStencilsAsText(ARRMeshActor* InActor)
+FString URRUObjectUtils::GetSegMaskDepthStencilsAsText(AActor* InActor)
 {
     TArray<uint8> depthStencilValueList;
 
-    // The validity and uniqueness of [meshComp's CustomDepthStencilValue] should have been already verified
-    for (const auto& meshComp : InActor->MeshCompList)
+    if (ARRMeshActor* meshActor = Cast<ARRMeshActor>(InActor))
     {
-        depthStencilValueList.AddUnique(static_cast<uint8>(meshComp->CustomDepthStencilValue));
+        // The validity and uniqueness of [meshComp's CustomDepthStencilValue] should have been already verified
+        for (const auto& meshComp : meshActor->MeshCompList)
+        {
+            depthStencilValueList.AddUnique(
+                DATA_SYNTH_CUSTOM_DEPTH_STENCILS[static_cast<uint8>(meshComp->CustomDepthStencilValue)]);
+        }
+    }
+    else if (AStaticMeshActor* staticMeshActor = Cast<AStaticMeshActor>(InActor))
+    {
+        depthStencilValueList.Add(DATA_SYNTH_CUSTOM_DEPTH_STENCILS[static_cast<uint8>(
+            staticMeshActor->GetStaticMeshComponent()->CustomDepthStencilValue)]);
     }
 
     return FString::JoinBy(
@@ -286,6 +388,19 @@ UMaterialInstanceDynamic* URRUObjectUtils::CreateMeshCompMaterialInstance(UMeshC
         InMaterialIndex, URRGameSingleton::Get()->GetMaterial(InMaterialInterfaceName), FName(*dynamicMaterialName));
 }
 
+int32 URRUObjectUtils::GetActorMaterialsNum(AActor* InActor)
+{
+    if (auto* meshActor = Cast<ARRMeshActor>(InActor))
+    {
+        return meshActor->BaseMeshComp->GetMaterials().Num();
+    }
+    else if (auto* staticMeshActor = Cast<AStaticMeshActor>(InActor))
+    {
+        return staticMeshActor->GetStaticMeshComponent()->GetMaterials().Num();
+    }
+    return 0;
+}
+
 UMaterialInstanceDynamic* URRUObjectUtils::GetActorBaseMaterial(AActor* InActor, int32 InMaterialIndex)
 {
     UMaterialInstanceDynamic* baseMaterial = nullptr;
@@ -300,33 +415,55 @@ UMaterialInstanceDynamic* URRUObjectUtils::GetActorBaseMaterial(AActor* InActor,
     return baseMaterial;
 }
 
-bool URRUObjectUtils::ApplyMeshActorMaterialProps(AActor* InActor, const FRRMaterialProperty& InMaterialInfo)
+bool URRUObjectUtils::ApplyMeshActorMaterialProps(AActor* InActor,
+                                                  const FRRMaterialProperty& InMaterialInfo,
+                                                  bool bApplyManufacturingAlbedo)
 {
-    UMaterialInstanceDynamic* baseMaterial = GetActorBaseMaterial(InActor);
-    if (baseMaterial)
+    URRGameSingleton* gameSingleton = URRGameSingleton::Get();
+    for (auto i = 0; i < GetActorMaterialsNum(InActor); ++i)
     {
-        ApplyMaterialProps(baseMaterial, InMaterialInfo);
-        return true;
+        UMaterialInstanceDynamic* baseMaterial = GetActorBaseMaterial(InActor, i);
+        if (baseMaterial)
+        {
+            ApplyMaterialProps(baseMaterial, InMaterialInfo, bApplyManufacturingAlbedo);
+            return true;
+        }
     }
     return false;
 }
 
-void URRUObjectUtils::ApplyMaterialProps(UMaterialInstanceDynamic* InMaterial, const FRRMaterialProperty& InMaterialInfo)
+void URRUObjectUtils::ApplyMaterialProps(UMaterialInstanceDynamic* InMaterial,
+                                         const FRRMaterialProperty& InMaterialInfo,
+                                         bool bApplyManufacturingAlbedo)
 {
     URRGameSingleton* gameSingleton = URRGameSingleton::Get();
+    static UTexture* blackMaskTexture = gameSingleton->GetTexture(URRGameSingleton::TEXTURE_NAME_BLACK_MASK);
+    static UTexture* whiteMaskTexture = gameSingleton->GetTexture(URRGameSingleton::TEXTURE_NAME_WHITE_MASK);
     // Albedo texture
-    if (InMaterialInfo.AlbedoTextureNameList.Num() > 0)
+    if (bApplyManufacturingAlbedo)
     {
-        InMaterial->SetTextureParameterValue(
-            FRRMaterialProperty::PROP_NAME_ALBEDO,
-            gameSingleton->GetTexture(URRMathUtils::GetRandomElement(InMaterialInfo.AlbedoTextureNameList)));
+        if (InMaterialInfo.AlbedoTextureNameList.Num() > 0)
+        {
+            InMaterial->SetTextureParameterValue(
+                FRRMaterialProperty::PROP_NAME_ALBEDO,
+                gameSingleton->GetTexture(URRMathUtils::GetRandomElement(InMaterialInfo.AlbedoTextureNameList)));
+        }
+        // Albedo color
+        InMaterial->SetVectorParameterValue(FRRMaterialProperty::PROP_NAME_COLOR_ALBEDO,
+                                            (InMaterialInfo.AlbedoColorList.Num() > 0)
+                                                ? URRMathUtils::GetRandomElement(InMaterialInfo.AlbedoColorList)
+                                                : URRMathUtils::GetRandomColor());
+        // Mask Texture: default White
+        InMaterial->SetTextureParameterValue(FRRMaterialProperty::PROP_NAME_MASK,
+                                             InMaterialInfo.MaskTextureName.IsEmpty()
+                                                 ? whiteMaskTexture
+                                                 : gameSingleton->GetTexture(InMaterialInfo.MaskTextureName));
     }
-
-    // Albedo color
-    InMaterial->SetVectorParameterValue(FRRMaterialProperty::PROP_NAME_COLOR_ALBEDO,
-                                        (InMaterialInfo.AlbedoColorList.Num() > 0)
-                                            ? URRMathUtils::GetRandomElement(InMaterialInfo.AlbedoColorList)
-                                            : URRMathUtils::GetRandomColor());
+    else
+    {
+        // Mask Texture: default Black
+        InMaterial->SetTextureParameterValue(FRRMaterialProperty::PROP_NAME_MASK, blackMaskTexture);
+    }
 
     // ORM Texture
     if (false == InMaterialInfo.ORMTextureName.IsEmpty())
@@ -341,13 +478,39 @@ void URRUObjectUtils::ApplyMaterialProps(UMaterialInstanceDynamic* InMaterial, c
         InMaterial->SetTextureParameterValue(FRRMaterialProperty::PROP_NAME_NORMAL,
                                              gameSingleton->GetTexture(InMaterialInfo.NormalTextureName));
     }
+}
 
-    // Mask Texture
-    if (false == InMaterialInfo.MaskTextureName.IsEmpty())
+bool URRUObjectUtils::SetMeshActorColor(AActor* InMeshActor, const FLinearColor& InColor)
+{
+    UMeshComponent* meshComp = nullptr;
+    if (auto* meshActor = Cast<ARRMeshActor>(InMeshActor))
     {
-        InMaterial->SetTextureParameterValue(FRRMaterialProperty::PROP_NAME_MASK,
-                                             gameSingleton->GetTexture(InMaterialInfo.MaskTextureName));
+        meshComp = meshActor->BaseMeshComp;
     }
+    else if (auto* staticMeshActor = Cast<AStaticMeshActor>(InMeshActor))
+    {
+        meshComp = staticMeshActor->GetStaticMeshComponent();
+    }
+    else
+    {
+        UE_LOG(LogRapyutaCore,
+               Error,
+               TEXT("SetMeshActorColor() [%s] is not ARRMeshActor or AStaticMeshActor"),
+               *InMeshActor->GetName());
+        return false;
+    }
+
+    static UTexture* blackMaskTexture = URRGameSingleton::Get()->GetTexture(URRGameSingleton::TEXTURE_NAME_BLACK_MASK);
+    for (auto i = 0; i < meshComp->GetMaterials().Num(); ++i)
+    {
+        UMaterialInstanceDynamic* material = Cast<UMaterialInstanceDynamic>(meshComp->GetMaterial(i));
+        if (material)
+        {
+            material->SetTextureParameterValue(FRRMaterialProperty::PROP_NAME_MASK, blackMaskTexture);
+            material->SetVectorParameterValue(FRRMaterialProperty::PROP_NAME_COLOR_ALBEDO, InColor);
+        }
+    }
+    return true;
 }
 
 void URRUObjectUtils::RandomizeActorAppearance(AActor* InActor, const FRRTextureData& InTextureData)

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
@@ -12,6 +12,8 @@
 #include "Core/RRMathUtils.h"
 #include "Core/RRMeshActor.h"
 
+//! Hardcoded [DATA_SYNTH_CUSTOM_DEPTH_STENCILS], due to UE5 mismatched pixels in captured image vs ones written into the custom depth buffer
+//! https://superyateam.com/2019/06/17/custom-depth-and-custom-depth-stencil-in-ue4/
 static TArray<uint8> DATA_SYNTH_CUSTOM_DEPTH_STENCILS = []()
 {
     TArray<uint8> data = {

--- a/Source/RapyutaSimulationPlugins/Private/Tools/OccupancyMapGenerator.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/OccupancyMapGenerator.cpp
@@ -3,6 +3,7 @@
 #include "Tools/OccupancyMapGenerator.h"
 
 #include "DrawDebugHelpers.h"
+#include "HAL/PlatformFileManager.h"
 #include "Misc/Paths.h"
 
 // Sets default values

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -80,6 +80,7 @@ enum class ERRFileType : uint8
 
     // Image
     IMAGE_JPG,
+    IMAGE_GRAYSCALE_JPG,
     IMAGE_PNG,
     IMAGE_TGA,
     IMAGE_EXR,

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -262,6 +262,8 @@ struct RAPYUTASIMULATIONPLUGINS_API FRREntityLogInfo
 {
     GENERATED_BODY()
 
+    //  NOTE: CustomDepthStencilValue, being used as segmaskid, is inherent to each meshcomp & assign once at creation
+    // & kept unchanged thus could be fetched directly from [Entity] at the logging moment
     FRREntityLogInfo()
     {
     }
@@ -550,19 +552,16 @@ public:
 
     //! Main environment actor if pre-setup in the level
     UPROPERTY()
-    AActor* MainEnvironment = nullptr;
+    AActor* SceneFloor = nullptr;
 
     //! Main floor actor if pre-setup in the level
-    UPROPERTY()
-    AActor* MainFloor = nullptr;
-
     //! Main wall actor if pre-setup in the level
     UPROPERTY()
-    AActor* MainWall = nullptr;
+    AActor* SceneWall = nullptr;
 
     //! Main camera actor used in the scene instance
     UPROPERTY()
-    ARRCamera* MainCamera = nullptr;
+    ARRCamera* SceneCamera = nullptr;
 
     //! Print sim config vars in INI
     virtual void PrintSimConfig() const;
@@ -592,7 +591,6 @@ public:
     //! Setup the scene instance's environment
     virtual void SetupEnvironment();
     //! Move the common main environment to another scene instance
-    void MoveEnvironmentToSceneInstance(int8 InSceneInstanceId);
 
     //! Callback on a mesh actor being fully created in the scene
     FOnMeshActorFullyCreated OnMeshActorFullyCreated;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -297,6 +297,7 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRHomoMeshEntityGroup
     UPROPERTY()
     TArray<ARRMeshActor*> Entities;
 
+    //! Fetch #Entities as TArray<AActor*>
     TArray<AActor*> GetActors() const
     {
         TArray<AActor*> actors;
@@ -307,16 +308,20 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRHomoMeshEntityGroup
         return actors;
     }
 
+    //! Fetch Entities[Index]
     ARRMeshActor* operator[](int32 Index) const
     {
         return Entities[Index];
     }
 
+    //! Get num of Entities
     int32 Num() const
     {
         return Entities.Num();
     }
+    //! Get Entities Group's common model name
     FString GetGroupModelName() const;
+    //! Get unique name of the entities group
     FString GetGroupName() const;
 };
 
@@ -351,27 +356,35 @@ struct RAPYUTASIMULATIONPLUGINS_API FRREntityLogInfo
     UPROPERTY()
     TArray<AActor*> Entities;
 
+    //! Common model name of the Entities group
     UPROPERTY()
     FString GroupModelName;
 
+    //! Unique name of the entities group
     UPROPERTY()
     FString GroupName;
 
+    //! Segmentation mask custom depth stencil hexa values in string format
     UPROPERTY()
     FString SegMaskDepthStencilStr;
 
+    //! Id of the current scene entities group belong to
     UPROPERTY()
     uint64 SceneId = 0;
 
+    //! World transform of the whole entities group
     UPROPERTY()
     FTransform WorldTransform = FTransform::Identity;
 
+    //! Bounding box 3D vertices of the whole group in world coordinate
     UPROPERTY()
     TArray<FVector> BBVertices3DInWorld;
 
+    //! Bounding box 3D vertices of the whole group in camera coordinate
     UPROPERTY()
     TArray<FVector> BBVertices3DInCamera;
 
+    //! Bounding box 2D vertices of the whole group, as projected onto camera
     UPROPERTY()
     TArray<FVector2D> BBVertices2D;
 };

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -386,7 +386,8 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRActorSpawnInfo
                       const TArray<FString>& InMaterialNameList = TArray<FString>(),
                       bool bInIsStationary = false,
                       bool bInIsPhysicsEnabled = false,
-                      bool bInIsCollisionEnabled = false);
+                      bool bInIsCollisionEnabled = false,
+                      bool bInIsOverlapEventEnabled = false);
 
     void operator()(const FString& InEntityModelName,
                     const FString& InUniqueName,
@@ -396,7 +397,8 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRActorSpawnInfo
                     const TArray<FString>& InMaterialNameList = TArray<FString>(),
                     bool bInIsStationary = false,
                     bool bInIsPhysicsEnabled = false,
-                    bool bInIsCollisionEnabled = false);
+                    bool bInIsCollisionEnabled = false,
+                    bool bInIsOverlapEventEnabled = false);
 
     void ClearMeshInfo()
     {
@@ -442,6 +444,9 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRActorSpawnInfo
 
     UPROPERTY()
     uint8 bIsSelfCollision : 1;
+
+    UPROPERTY()
+    uint8 bIsOverlapEventEnabled : 1;
 
     UPROPERTY()
     uint8 bIsDataSynthEntity : 1;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -85,6 +85,9 @@ enum class ERRFileType : uint8
     IMAGE_EXR,
     IMAGE_HDR,
 
+    // Light Profile
+    LIGHT_PROFILE_IES,
+
     // Meta Data
     JSON,
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
@@ -122,6 +122,7 @@ public:
 
         // Image
         TEXT(".jpg"),    // ERRFileType::IMAGE_JPG
+        TEXT(".jpg"),    // ERRFileType::IMAGE_GRAYSCALE_JPG
         TEXT(".png"),    // ERRFileType::IMAGE_PNG
         TEXT(".tga"),    // ERRFileType::IMAGE_TGA
         TEXT(".exr"),    // ERRFileType::IMAGE_EXR

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
@@ -15,6 +15,7 @@
 #include "UnrealEd.h"
 #endif
 #include "Delegates/Delegate.h"
+#include "Engine/TextureLightProfile.h"
 #include "Engine/World.h"
 #include "IImageWrapper.h"
 #include "IImageWrapperModule.h"
@@ -28,6 +29,7 @@
 
 // RapyutaSimulationPlugins
 #include "Core/RRActorCommon.h"
+#include "Core/RRTextureData.h"
 #include "Core/RRTypeUtils.h"
 
 #include "RRCoreUtils.generated.h"
@@ -125,6 +127,9 @@ public:
         TEXT(".tga"),    // ERRFileType::IMAGE_TGA
         TEXT(".exr"),    // ERRFileType::IMAGE_EXR
         TEXT(".hdr"),    // ERRFileType::IMAGE_HDR
+
+        // Light Profile
+        TEXT(".ies"),    // ERRFileType::LIGHT_PROFILE_IES
 
         // Meta data
         TEXT(".json"),    // ERRFileType::JSON
@@ -467,6 +472,14 @@ public:
                                      const TArray<ERRFileType>& InImageFileTypes,
                                      TArray<UTexture*>& OutImageTextureList,
                                      bool bIsLogged = false);
+
+    static FRRLightProfileData SLightProfileData;
+    static UTextureLightProfile* LoadIESProfile(const FString& InFullFilePath, const FString& InLightProfileName);
+    static bool LoadIESProfilesFromFolder(const FString& InFolderPath,
+                                          TArray<UTextureLightProfile*>& OutLightProfileList,
+                                          bool bIsLogged = false);
+
+    static TFunction<void(uint8*, const FUpdateTextureRegion2D*)> CleanupLightProfileData;
 
     static bool IsValidBitDepth(int32 InBitDepth)
     {

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -37,6 +37,13 @@ public:
     static URRGameSingleton* Get();
     virtual ~URRGameSingleton();
 
+    virtual void PrintSimConfig() const;
+
+    // SIM GLOBAL PROPERTIES --
+    //
+    UPROPERTY(config)
+    bool BSIM_PROFILING = false;
+
     // SIM RESOURCES ==
     //
     bool InitializeResources();

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -129,6 +129,10 @@ public:
                 }
                 break;
 
+            case ERRResourceDataType::UE_TEXTURE:
+                ProcessAsyncLoadedResource<UTexture>(InDataType, InResourcePath, InResourceUniqueName);
+                break;
+
             default:
                 break;
         }
@@ -338,7 +342,7 @@ public:
     }
 
     // MATERIALS --
-    // Material Entities Info folder path
+    // Dynamic Material assets folder path
     UPROPERTY(config)
     FString FOLDER_PATH_ASSET_MATERIALS = TEXT("Materials");
 
@@ -346,6 +350,7 @@ public:
     static constexpr const TCHAR* MATERIAL_NAME_ASSET_MASTER = TEXT("M_RapyutaAssetMaster");
     static constexpr const TCHAR* MATERIAL_NAME_PROP_MASTER = TEXT("M_RapyutaPropMaster");
     static constexpr const TCHAR* MATERIAL_NAME_PHYSICS_WHEEL = TEXT("PM_Wheel");
+    static constexpr const TCHAR* MATERIAL_NAME_TRANSLUCENCE_MASTER = TEXT("M_RapyutaTranslucenceMaster");
 
     FORCEINLINE UMaterialInterface* GetMaterial(const FString& InMaterialName) const
     {
@@ -357,6 +362,12 @@ public:
     }
 
     // TEXTURES --
+    // Dynamic Texture assets folder path
+    UPROPERTY(config)
+    FString FOLDER_PATH_ASSET_TEXTURES = TEXT("Textures");
+
+    static constexpr const TCHAR* TEXTURE_NAME_WHITE_MASK = TEXT("T_WhiteMask");
+    static constexpr const TCHAR* TEXTURE_NAME_BLACK_MASK = TEXT("T_BlackMask");
     FORCEINLINE UTexture* GetTexture(const FString& InTextureName) const
     {
         return GetSimResource<UTexture>(ERRResourceDataType::UE_TEXTURE, InTextureName);

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
@@ -159,14 +159,18 @@ public:
         }
     }
 
+    //! Move all env static actors to a scene instance
     virtual void MoveEnvironmentToSceneInstance(int8 InSceneInstanceId);
 
 protected:
     virtual void CreateSceneInstance(int8 InSceneInstanceId);
     virtual void InitializeSim(int8 InSceneInstanceId);
     virtual void StartSubSim(int8 InSceneInstanceId);
+    //! Create scene's common objects
     virtual void CreateServiceObjects(int8 InSceneInstanceId);
+    //! Stream level & Fetch static-env actors
     virtual void SetupEnvironment();
+    //! Fetch env static actors (floors, walls, lights, etc.) if setup in the scene/level
     virtual void FetchEnvStaticActors();
 
     virtual void FinalizeSim();

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
@@ -13,6 +13,7 @@
 
 // RapyutaSimulationPlugins
 #include "Core/RRActorCommon.h"
+#include "Core/RRConversionUtils.h"
 
 #include "RRGameState.generated.h"
 
@@ -49,7 +50,9 @@ public:
     URRGameInstance* GameInstance = nullptr;
 
     UPROPERTY(config)
-    float SCENE_INSTANCES_DISTANCE_INTERVAL = 200.f;
+    float SCENE_INSTANCES_DISTANCE_INTERVAL = 5000.f;
+    UPROPERTY()
+    int8 LastSceneInstanceId = URRActorCommon::DEFAULT_SCENE_INSTANCE_ID;
 
     UPROPERTY()
     TArray<URRSceneInstance*> SceneInstanceList;
@@ -74,11 +77,9 @@ public:
 
     virtual bool HaveAllSceneInstancesCompleted() const;
 
-    // ENV
+    // ENVIRONMENT
     UPROPERTY()
     AActor* MainEnvironment = nullptr;
-    UPROPERTY()
-    FVector MainEnvOriginalLocation = FVector::ZeroVector;
 
     UPROPERTY()
     AActor* MainFloor = nullptr;
@@ -88,9 +89,6 @@ public:
 
     UPROPERTY()
     TArray<ALight*> MainLights;
-
-    UPROPERTY()
-    TArray<AStaticMeshActor*> MainStaticMeshActors;
 
     // SIM OUTPUTS
     UPROPERTY(config)
@@ -107,18 +105,21 @@ public:
 
     // ENTITIES
     /* The vertex normals
+     * INI in ROS
       7 -- 4      Z
      /|   /|      |
     2-1--5 6      | Y
     |/   |/       |/
     0 -- 3         -----X
 
+     * UE
     4 -- 7         Z
     |\   |\     Y  |
     6 5--1 2     \ |
      \|   \|      \|
       3 -- 0  X----
      */
+    // NOTE: THESE ARE CONFIGURED BY USERS IN ROS RIGHT-HANDED COORD FOR CONVENIENCE, THUS THE INDEX ORDERING FOLLOWS CLOCK-WISE
     UPROPERTY(config)
     TArray<FVector> ENTITY_BOUNDING_BOX_VERTEX_NORMALS = {
         {0.f, 0.f, 0.f},    //[0]
@@ -130,12 +131,24 @@ public:
         {1.f, 1.f, 0.f},    //[6]
         {0.f, 1.f, 1.f},    //[7]
     };
-    ARRMeshActor* FindEntityByModel(const FString& InEntityModelName, bool bToActivate, bool bToTakeAway);
-    void SetAllEntitiesActivated(bool bIsActivated);
-    FORCEINLINE void AddEntity(ARRMeshActor* InEntity)
+
+    // UE LEFT-HANDED COUNTER-CLOCKWISE ORDERING
+    FORCEINLINE FVector GetEntityBBVertexNormal(int8 InVertexIdx)
     {
-        AllDynamicMeshEntities.AddUnique(InEntity);
+        static const TArray<FVector> bbVertexNormals = {ENTITY_BOUNDING_BOX_VERTEX_NORMALS[3],
+                                                        ENTITY_BOUNDING_BOX_VERTEX_NORMALS[6],
+                                                        ENTITY_BOUNDING_BOX_VERTEX_NORMALS[5],
+                                                        ENTITY_BOUNDING_BOX_VERTEX_NORMALS[0],
+                                                        ENTITY_BOUNDING_BOX_VERTEX_NORMALS[7],
+                                                        ENTITY_BOUNDING_BOX_VERTEX_NORMALS[2],
+                                                        ENTITY_BOUNDING_BOX_VERTEX_NORMALS[1],
+                                                        ENTITY_BOUNDING_BOX_VERTEX_NORMALS[4]};
+        return bbVertexNormals[InVertexIdx];
     }
+
+    void SetAllEntitiesActivated(bool bIsActivated);
+    ARRMeshActor* FindEntityByModel(const FString& InEntityModelName, bool bToActivate, bool bToTakeAway);
+    void AddEntity(ARRMeshActor* InEntity);
 
     template<typename T>
     void AddEntities(const TArray<T*> InEntityList)
@@ -146,23 +159,21 @@ public:
         }
     }
 
-    void MoveEnvironmentToSceneInstance(int8 InSceneInstanceId);
+    virtual void MoveEnvironmentToSceneInstance(int8 InSceneInstanceId);
 
 protected:
     virtual void CreateSceneInstance(int8 InSceneInstanceId);
     virtual void InitializeSim(int8 InSceneInstanceId);
     virtual void StartSubSim(int8 InSceneInstanceId);
     virtual void CreateServiceObjects(int8 InSceneInstanceId);
-    virtual void FetchEnvironmentActors();
+    virtual void SetupEnvironment();
+    virtual void FetchEnvStaticActors();
 
     virtual void FinalizeSim();
     virtual void PrintSimConfig() const;
     virtual void BeginPlay() override;
     virtual void BeginSubPlay();
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
-
-    virtual void Tick(float DeltaTime) override;
-    virtual void OnTick(float DeltaTime);
 
 protected:
     UPROPERTY()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
@@ -74,6 +74,24 @@ public:
 
     virtual bool HaveAllSceneInstancesCompleted() const;
 
+    // ENV
+    UPROPERTY()
+    AActor* MainEnvironment = nullptr;
+    UPROPERTY()
+    FVector MainEnvOriginalLocation = FVector::ZeroVector;
+
+    UPROPERTY()
+    AActor* MainFloor = nullptr;
+
+    UPROPERTY()
+    AActor* MainWall = nullptr;
+
+    UPROPERTY()
+    TArray<ALight*> MainLights;
+
+    UPROPERTY()
+    TArray<AStaticMeshActor*> MainStaticMeshActors;
+
     // SIM OUTPUTS
     UPROPERTY(config)
     FString SIM_OUTPUTS_BASE_FOLDER_NAME = TEXT("OutputData");
@@ -128,11 +146,14 @@ public:
         }
     }
 
+    void MoveEnvironmentToSceneInstance(int8 InSceneInstanceId);
+
 protected:
     virtual void CreateSceneInstance(int8 InSceneInstanceId);
     virtual void InitializeSim(int8 InSceneInstanceId);
     virtual void StartSubSim(int8 InSceneInstanceId);
     virtual void CreateServiceObjects(int8 InSceneInstanceId);
+    virtual void FetchEnvironmentActors();
 
     virtual void FinalizeSim();
     virtual void PrintSimConfig() const;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRMathUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRMathUtils.h
@@ -198,6 +198,15 @@ public:
         return color.HSVToLinearRGB();
     }
 
+    FORCEINLINE static FLinearColor GetRandomColorFromHSV(const TArray<FVector2D>& InHSVRange)
+    {
+        FLinearColor color(GetRandomFloatInRange(InHSVRange[0].X, InHSVRange[0].Y),     // Hue
+                           GetRandomFloatInRange(InHSVRange[1].X, InHSVRange[1].Y),     // Saturation
+                           GetRandomFloatInRange(InHSVRange[2].X, InHSVRange[2].Y));    // Value
+
+        return color.HSVToLinearRGB();
+    }
+
     FORCEINLINE static FLinearColor GetRandomColor()
     {
         return FLinearColor(GetRandomBias(), GetRandomBias(), GetRandomBias(), GetRandomBias());

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
@@ -110,6 +110,7 @@ public:
                 ActorInfo->bIsStationary,
                 ActorInfo->bIsPhysicsEnabled,
                 ActorInfo->bIsCollisionEnabled,
+                ActorInfo->bIsOverlapEventEnabled,
                 InParentComp);
 
             if (meshComp)

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRPlayerController.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRPlayerController.h
@@ -47,7 +47,7 @@ public:
     URRActorCommon* ActorCommon = nullptr;
 
     UPROPERTY()
-    ARRCamera* MainCamera = nullptr;
+    ARRCamera* SceneCamera = nullptr;
 
     UPROPERTY()
     FPostProcessSettings PostProcessSettings;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRProceduralMeshComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRProceduralMeshComponent.h
@@ -90,7 +90,7 @@ public:
 
     // Collision/Overlapping --
     void SetCollisionModeAvailable(bool bIsOn, bool bIsHitEventEnabled = false);
-    void EnableOverlapping();
+    void EnableOverlapping(bool bOverlapEventEnabled);
 
     bool IsMeshDataValid() const;
     bool GetMeshData(FRRMeshData& OutMeshData, bool bFromBuffer);

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRSceneDirector.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRSceneDirector.h
@@ -48,7 +48,7 @@ public:
     APostProcessVolume* MainPostProcessVolume = nullptr;
 
     UPROPERTY()
-    ARRCamera* MainCamera = nullptr;
+    ARRCamera* SceneCamera = nullptr;
 
     UFUNCTION()
     bool HasSceneInitialized()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRSceneDirector.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRSceneDirector.h
@@ -60,6 +60,9 @@ public:
 
     virtual bool HasOperationCompleted(bool bIsLogged = false);
 
+    UPROPERTY()
+    double DataCollectionTimeStamp = 0.f;
+
 protected:
     virtual bool Initialize() override;
     virtual void Tick(float DeltaTime) override;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRSceneDirector.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRSceneDirector.h
@@ -63,9 +63,11 @@ public:
     UPROPERTY()
     double DataCollectionTimeStamp = 0.f;
 
+    UPROPERTY()
+    TArray<int32> SceneEntityMaskValueList;
+
 protected:
     virtual bool Initialize() override;
-    virtual void Tick(float DeltaTime) override;
 
     // Start (Initialize + Run) Operation
     virtual bool InitializeOperation();
@@ -76,6 +78,9 @@ protected:
 
     virtual void OnDataCollectionPhaseDone(bool bIsFinalDataCollectingPhase);
     virtual void EndSceneInstance();
+
+    UPROPERTY()
+    FTimerHandle InitializationTimerHandle;
 
     UPROPERTY()
     FTimerHandle DataCollectionTimerHandle;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRStaticMeshComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRStaticMeshComponent.h
@@ -87,7 +87,7 @@ public:
     UFUNCTION()
     void SetCollisionModeAvailable(bool bInCollisionEnabled, bool bInHitEventEnabled = false);
     UFUNCTION()
-    void EnableOverlapping();
+    void EnableOverlapping(bool bOverlapEventEnabled);
 
 protected:
     virtual void BeginPlay() override;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRTextureData.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRTextureData.h
@@ -20,3 +20,19 @@ public:
 
     UTexture* GetRandomTexture() const;
 };
+
+// Ref: DatasmithRuntime::FTextureData
+struct RAPYUTASIMULATIONPLUGINS_API FRRLightProfileData
+{
+public:
+    EPixelFormat PixelFormat = EPixelFormat::PF_Unknown;
+    int32 Width = 0;
+    int32 Height = 0;
+    uint32 Pitch = 0;
+    int16 BytesPerPixel = 0;
+    FUpdateTextureRegion2D Region = {0, 0, 0, 0, 0, 0};
+    uint8* ImageData = nullptr;
+    // For IES profile
+    float Brightness = -FLT_MAX;
+    float TextureMultiplier = -FLT_MAX;
+};

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRThreadUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRThreadUtils.h
@@ -95,7 +95,7 @@ public:
     }
     template<typename TResult>
     static void AddAsyncTaskInThreadPool(FRRAsyncJob& OutAsyncJob,
-                                         const uint64& InCurrentCaptureBatchId,
+                                         const uint64 InCurrentCaptureBatchId,
                                          TFunction<TResult()> InTask,
                                          TFunction<void()> InCompletionCallback)
     {
@@ -112,7 +112,7 @@ public:
 
     template<typename TResult>
     static void AddAsyncTaskToJob(FRRAsyncJob& OutAsyncJob,
-                                  const uint64& InCurrentCaptureBatchId,
+                                  const uint64 InCurrentCaptureBatchId,
                                   TFunction<TResult()> InTask,
                                   TFunction<void()> InCompletionCallback,
                                   const EAsyncExecution InExecutionThread = EAsyncExecution::ThreadPool)

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRUObjectUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRUObjectUtils.h
@@ -264,6 +264,7 @@ public:
                                                            bool bInIsOwningActorStationary,
                                                            bool bInIsPhysicsEnabled,
                                                            bool bInIsCollisionEnabled,
+                                                           bool bInIsOverlapEventEnabled = false,
                                                            USceneComponent* InParentComp = nullptr)
     {
         // 1 - Create --
@@ -290,7 +291,7 @@ public:
         // Overlapping --
         if (!bInIsPhysicsEnabled && !bInIsCollisionEnabled)
         {
-            meshComp->EnableOverlapping();
+            meshComp->EnableOverlapping(bInIsOverlapEventEnabled);
         }
 
         // Stationary --

--- a/Source/RapyutaSimulationPlugins/RapyutaSimulationPlugins.Build.cs
+++ b/Source/RapyutaSimulationPlugins/RapyutaSimulationPlugins.Build.cs
@@ -43,7 +43,7 @@ public class RapyutaSimulationPlugins : ModuleRules
         CppStandard = CppStandardVersion.Cpp17;
         bEnableExceptions = true;
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "Renderer", "RHI", "PhysicsCore",  "XmlParser",
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "Renderer", "RHI", "PhysicsCore", "XmlParser", "IESFile",
                                                             "AIModule", "NavigationSystem", "TimeManagement", "Json",
                                                             "ChaosVehicles",
                                                             "ProceduralMeshComponent", "MeshDescription", "StaticMeshDescription", "MeshConversion",


### PR DESCRIPTION
The branch has been developed for a while mostly for the warehouse data synth app and needs to be merged to save maintenance burden & avoid ongoing conflicts with mainstream dev. It contains the following warehouse-related utils:
* Dynamic texture loading from HDR & object coating at runtime, which is used for pallets & boxes.
* Dynamic Level streaming at run time, which is gonna be used to load arbitrary photorealistic warehouse maps by @StefanIvanovTA to `RapyutaGeneric`
* Dynamic realistic light profile/IES loading
* `FRRActorSpawnInfo` add bIsOverlapEventEnabled;RRProceduralMeshComponent, RRStaticMeshComponent pass it to EnableOverlapping()

`ARRMeshActor`
* Segmentation mask value assigning using CutomDepthStencils, currently hardcoded due to incorrect pixel capturing in UE5
* Bulk-homogeneous-entities segmask value assigning (like a stack of pallets as in a common segmentation)