### PR TITLE
RRCrowdFollowingComp enable crowd sim

### DIFF
--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCrowdFollowingComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCrowdFollowingComponent.h
@@ -23,9 +23,6 @@ public:
     URRCrowdFollowingComponent(const FObjectInitializer& ObjectInitializer);
 
     UPROPERTY()
-    float MaxCrowdSpeed = 0.f;
-
-    UPROPERTY()
     URRFloatingMovementComponent* FloatMovementComp = nullptr;
     virtual void SetMovementComponent(UNavMovementComponent* InMoveComp) override;
     bool Is2DMovement() const;


### PR DESCRIPTION
RRCrowdFollowingComp
- Enable crowd sim, putting AvoidanceQuality to Good by default
- Rem `MaxCrowdSpeed`, using `GetCrowdAgentMaxSpeed()`
To be duplication resolved with https://github.com/rapyuta-robotics/RapyutaSimulationPlugins/pull/131