### PR TITLE
AutoRegister user-specified BP Classes as Spawnable Entity types

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
@@ -67,6 +67,9 @@ void ARRGameState::StartSim()
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("MAX SPLIT SCREEN PLAYERS: %d"), maxSplitscreenPlayers);
     verify(SCENE_INSTANCES_NUM <= maxSplitscreenPlayers);
 
+    // Register BP spawnable classes
+    RegisterSpawnableBPClasses();
+
     // 0- Stream level & Fetch static-env actors
     SetupEnvironment();
 
@@ -86,6 +89,19 @@ void ARRGameState::StartSim()
         InitializeSim(i);
 
         UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("SIM SCENE INSTANCE [%d] STARTED SUCCESSFULLY! "), i);
+    }
+}
+
+void ARRGameState::RegisterSpawnableBPClasses()
+{
+    auto* mainSimState = GameMode->MainSimState;
+    for (const auto& bpName : BPSpawnableClassNames)
+    {
+        UClass* bpClass = URRAssetUtils::FindBlueprintClass(bpName);
+        if (bpClass)
+        {
+            mainSimState->AddSpawnableEntityTypes({{bpName, bpClass}});
+        }
     }
 }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
@@ -67,9 +67,6 @@ void ARRGameState::StartSim()
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("MAX SPLIT SCREEN PLAYERS: %d"), maxSplitscreenPlayers);
     verify(SCENE_INSTANCES_NUM <= maxSplitscreenPlayers);
 
-    // Register BP spawnable classes
-    RegisterSpawnableBPClasses();
-
     // 0- Stream level & Fetch static-env actors
     SetupEnvironment();
 
@@ -89,19 +86,6 @@ void ARRGameState::StartSim()
         InitializeSim(i);
 
         UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("SIM SCENE INSTANCE [%d] STARTED SUCCESSFULLY! "), i);
-    }
-}
-
-void ARRGameState::RegisterSpawnableBPClasses()
-{
-    auto* mainSimState = GameMode->MainSimState;
-    for (const auto& bpName : BPSpawnableClassNames)
-    {
-        UClass* bpClass = URRAssetUtils::FindBlueprintClass(bpName);
-        if (bpClass)
-        {
-            mainSimState->AddSpawnableEntityTypes({{bpName, bpClass}});
-        }
     }
 }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRMeshActor.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRMeshActor.cpp
@@ -11,7 +11,7 @@
 #include "Core/RRUObjectUtils.h"
 
 using URRMeshComponent =
-    typename TChooseClass<RAPYUTA_DATA_SYNTH_USE_ENTITY_STATIC_MESH, URRStaticMeshComponent, URRProceduralMeshComponent>::Result;
+    typename TChooseClass<RAPYUTA_RUNTIME_MESH_ENTITY_USE_STATIC_MESH, URRStaticMeshComponent, URRProceduralMeshComponent>::Result;
 
 ARRMeshActor::ARRMeshActor()
 {

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRROS2GameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRROS2GameMode.cpp
@@ -46,7 +46,9 @@ void ARRROS2GameMode::InitSim()
 {
     // 1- Simulation state
     MainSimState = GetWorld()->SpawnActor<ASimulationState>();
-    // Fetch Entities in the map first regardless of ROS2
+    // 1.1- Register BP spawnable classes
+    MainSimState->RegisterSpawnableBPEntities(BPSpawnableClassNames);
+    // 1.2- Fetch Entities in the map first regardless of ROS2
     MainSimState->InitEntities();
 
     // 2 - Init Sim-wide Main ROS2 node, but only in case of a Network standalone app

--- a/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
@@ -18,6 +18,7 @@
 
 // RapyutaSimulationPlugins
 #include "Core/RRActorCommon.h"
+#include "Core/RRAssetUtils.h"
 #include "Core/RRConversionUtils.h"
 #include "Core/RRUObjectUtils.h"
 #include "Net/UnrealNetwork.h"
@@ -46,6 +47,18 @@ bool ASimulationState::VerifyIsServerCall(const FString& InFunctionName)
         return false;
     }
     return true;
+}
+
+void ASimulationState::RegisterSpawnableBPEntities(const TArray<FString>& InBPSpawnableClassNames)
+{
+    for (const auto& bpName : InBPSpawnableClassNames)
+    {
+        UClass* bpClass = URRAssetUtils::FindBlueprintClass(bpName);
+        if (bpClass)
+        {
+            AddSpawnableEntityTypes({{bpName, bpClass}});
+        }
+    }
 }
 
 void ASimulationState::InitEntities()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -30,8 +30,8 @@
 #define RAPYUTA_SIM_DEBUG (0)
 #define RAPYUTA_SIM_VISUAL_DEBUG (0)
 
-#define RAPYUTA_DATA_SYNTH_USE_ENTITY_STATIC_MESH (0)
-#define RAPYUTA_DATA_SYNTH_USE_ENTITY_PROCEDURAL_MESH (!RAPYUTA_DATA_SYNTH_USE_ENTITY_STATIC_MESH)
+#define RAPYUTA_RUNTIME_MESH_ENTITY_USE_STATIC_MESH (1)
+#define RAPYUTA_RUNTIME_MESH_ENTITY_USE_PROCEDURAL_MESH (!RAPYUTA_RUNTIME_MESH_ENTITY_USE_STATIC_MESH)
 
 class ARRGameMode;
 class ARRGameState;
@@ -161,7 +161,7 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRAsyncJob
     {
         //! [TSharedFuture] should be considered if [Task] is accessed from multiple threads!
         TFuture<TResult> Task;
-        
+
         bool DoneStatus = false;
 
         FRRSingleAsyncTask()
@@ -207,10 +207,10 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRAsyncJob
     static constexpr const int8 TASK_INDEX_NONE = -1;
 
     FString JobName;
-    
+
     //! This stores the up-to-the-moment capture batch id every time an async task is added to be scheduled for running!
     uint64 LatestCaptureBatchId = 0;
-    
+
     TArray<FRRSingleAsyncTask<bool>> AsyncTasks;
 
     // For the future of UE C++
@@ -695,7 +695,7 @@ public:
 
     //! Callback on ARRGameState::StartSim() for this scene instance
     virtual void OnStartSim();
-    
+
     //! Callback on ARRGameState::BeginPlay() for this scene instance
     virtual void OnBeginPlay()
     {

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCrowdFollowingComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCrowdFollowingComponent.h
@@ -23,7 +23,7 @@ public:
     URRCrowdFollowingComponent(const FObjectInitializer& ObjectInitializer);
 
     UPROPERTY()
-    URRFloatingMovementComponent* FloatMovementComp = nullptr;
+    TObjectPtr<URRFloatingMovementComponent> FloatMovementComp = nullptr;
     virtual void SetMovementComponent(UNavMovementComponent* InMoveComp) override;
     bool Is2DMovement() const;
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
@@ -257,10 +257,6 @@ protected:
     UPROPERTY()
     TArray<ARRMeshActor*> AllDynamicMeshEntities;
 
-    UPROPERTY()
-    TArray<FString> BPSpawnableClassNames;
-    virtual void RegisterSpawnableBPClasses();
-
 private:
     //! To avoid early GC, this exists only to keep ones temporarily taken away from [AllDynamicMeshEntities] & recycled later
     UPROPERTY()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
@@ -194,7 +194,7 @@ protected:
     * @param InSceneInstanceId 
     */
     virtual void CreateSceneInstance(int8 InSceneInstanceId);
-    
+
     /**
      * @brief 
      * Spawn #ARRSceneDirector, which runs the main operation of the mode
@@ -256,6 +256,10 @@ protected:
     //! Pool of all entities having been spawned
     UPROPERTY()
     TArray<ARRMeshActor*> AllDynamicMeshEntities;
+
+    UPROPERTY()
+    TArray<FString> BPSpawnableClassNames;
+    virtual void RegisterSpawnableBPClasses();
 
 private:
     //! To avoid early GC, this exists only to keep ones temporarily taken away from [AllDynamicMeshEntities] & recycled later

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRROS2GameMode.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRROS2GameMode.h
@@ -114,6 +114,9 @@ protected:
      */
     virtual void StartPlay() override;
 
+    UPROPERTY()
+    TArray<FString> BPSpawnableClassNames;
+
 private:
     /**
      * @brief Create and initialize #MainROS2Node, #ClockPublisher and #MainSimState.

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRROS2GameMode.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRROS2GameMode.h
@@ -114,6 +114,7 @@ protected:
      */
     virtual void StartPlay() override;
 
+    //! Blueprint class names to be registered as spawnable entity types
     UPROPERTY()
     TArray<FString> BPSpawnableClassNames;
 

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -85,11 +85,11 @@ public:
 
     FORCEINLINE bool IsDynamicRuntimeRobot() const
     {
-        return (false == RobotModelName.IsEmpty());
+        return (false == IsStaticBPRobot());
     }
     FORCEINLINE bool IsStaticBPRobot() const
     {
-        return RobotModelName.IsEmpty();
+        return RobotModelName.IsEmpty() || GetClass()->GetName().StartsWith(TEXT("BP"));
     }
 
     //! Robot creation done delegate

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -89,7 +89,9 @@ public:
     }
     FORCEINLINE bool IsStaticBPRobot() const
     {
-        return GetClass()->GetName().StartsWith(TEXT("BP")) || GetClass()->GetName().StartsWith(TEXT("SKEL_BP"));
+        const FString className = GetClass()->GetName();
+        return className.StartsWith(TEXT("BP"))             // In-Editor
+               || className.StartsWith(TEXT("SKEL_BP"));    // In-Package auto prefixed [SKEL_]
     }
 
     //! Robot creation done delegate

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -89,7 +89,7 @@ public:
     }
     FORCEINLINE bool IsStaticBPRobot() const
     {
-        return RobotModelName.IsEmpty() || GetClass()->GetName().StartsWith(TEXT("BP"));
+        return GetClass()->GetName().StartsWith(TEXT("BP"));
     }
 
     //! Robot creation done delegate

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -89,7 +89,7 @@ public:
     }
     FORCEINLINE bool IsStaticBPRobot() const
     {
-        return GetClass()->GetName().StartsWith(TEXT("BP"));
+        return GetClass()->GetName().StartsWith(TEXT("BP")) || GetClass()->GetName().StartsWith(TEXT("SKEL_BP"));
     }
 
     //! Robot creation done delegate

--- a/Source/RapyutaSimulationPlugins/Public/Tools/SimulationState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Tools/SimulationState.h
@@ -90,6 +90,12 @@ public:
 
 public:
     /**
+     * @brief Register entity types from Blueprint class names, that are configured in #ARRROS2GameMode
+     */
+    UFUNCTION(BlueprintCallable)
+    void RegisterSpawnableBPEntities(const TArray<FString>& InBPSpawnableClassNames);
+
+    /**
      * @brief Fetch all entities in the current map under control of this Actor.
      */
     UFUNCTION(BlueprintCallable)


### PR DESCRIPTION
* ARRGameState add BPSpawnableClassNames + RegisterSpawnableBPClasses()
* URRAssetUtils Add FindBlueprintClass()
* ARRBaseRobot Requires static BP Robot to have its model name empty or prefixed with `BP`