### PR TITLE
ARRROS2GameMode add FRROnROS2Initialized

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRROS2GameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRROS2GameMode.cpp
@@ -85,6 +85,9 @@ void ARRROS2GameMode::InitROS2()
     // Create Clock publisher
     ClockPublisher =
         CastChecked<URRROS2ClockPublisher>(MainROS2Node->CreatePublisherWithClass(URRROS2ClockPublisher::StaticClass()));
+
+    // Signal [OnROS2Initialized]
+    OnROS2Initialized.Broadcast();
 }
 
 void ARRROS2GameMode::StartPlay()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRROS2GameMode.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRROS2GameMode.h
@@ -20,6 +20,8 @@
 class AROS2Node;
 class URRROS2ClockPublisher;
 
+DECLARE_MULTICAST_DELEGATE(FRROnROS2Initialized);
+
 /**
  * @brief ROS2 GameMode which have Clock publisher and ROS2 services to interact with ROS2.
  * @sa [AGameMode](https://docs.unrealengine.com/5.1/en-US/API/Runtime/Engine/GameFramework/AGameMode/)
@@ -58,6 +60,8 @@ public:
     UPROPERTY(BlueprintReadOnly)
     TSubclassOf<URRROS2SimulationStateClient> ROS2SimStateClientClass = URRROS2SimulationStateClient::StaticClass();
 
+    //! Delegate signalling ROS2 having been initialized with #MainROS2Node, #MainROS2SimStateClient, #ClockPublisher ready
+    FRROnROS2Initialized OnROS2Initialized;
     /**
      * @brief Set timestep by FApp::SetFixedDeltaTime.
      *


### PR DESCRIPTION
* Add FRROnROS2Initialized delegate to signify ROS2 framework objects having been ready for internal operations like automation test that uses ROS2 services, eg. to spawn entities.
Ref: ROS2 initialization has been moved to `ARRROS2GameMode::StartPlay()`, after all resources have been loaded in #135 
* URRRobotROS2Interface add OnMessageReceivedFunc accepting TFunction