### PR TITLE
added ability to retrieve world ref of the object as well

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Tools/ROS2Spawnable.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/ROS2Spawnable.cpp
@@ -32,6 +32,7 @@ void UROS2Spawnable::InitializeParameters(const FROSSpawnEntityReq& InRequest)
                      *InRequest.RobotNamespace,
                      *InRequest.RobotNamespace.Replace(TEXT("/"), TEXT("")));
     ActorNamespace = InRequest.RobotNamespace.Replace(TEXT("/"), TEXT(""));
+    ActorReferenceFrame = InRequest.State.ReferenceFrame;
 }
 
 void UROS2Spawnable::SetActorModelName(const FString& InModelName)

--- a/Source/RapyutaSimulationPlugins/Public/Tools/ROS2Spawnable.h
+++ b/Source/RapyutaSimulationPlugins/Public/Tools/ROS2Spawnable.h
@@ -39,6 +39,9 @@ public:
     UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Replicated)
     FString ActorJsonConfigs;
 
+    UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Replicated)
+    FString ActorReferenceFrame;
+    
     /**
      * @brief Set Actor name and ROS2 namespace from SpawnEntity service request.
      * @sa [ue_msgs/SpawnEntity.srv](https://github.com/rapyuta-robotics/UE_msgs/blob/devel/srv/SpawnEntity.srv)


### PR DESCRIPTION
For allowing the bin actors to remove and re-add the bins to the mesh correctly in https://github.com/rapyuta-robotics/oks_UE/pull/4, as the HISM mesh is offset on spawn by the origin