### PR TITLE
Refactor check to decouple with RR~ game framework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=500"]
@@ -12,13 +12,13 @@ repos:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort
         args: ["--profile", "black"]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         description: Format python code
@@ -27,13 +27,13 @@ repos:
         name: black with python3.8
         args: ["--line-length=88", "--target-version=py38"]
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         description: Linting for python code
         args: ["--max-line-length=88"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v13.0.1'
+    rev: 'v16.0.2'
     hooks:
       - id: clang-format
         name: clang-format

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
@@ -219,7 +219,7 @@ void URRActorCommon::PrintSimConfig() const
 
 void URRActorCommon::OnStartSim()
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     std::call_once(OnceFlag, [this]() { PrintSimConfig(); });
 #endif
     UWorld* currentWorld = GetWorld();
@@ -244,24 +244,24 @@ void URRActorCommon::SetupEnvironment()
         // Spawn Scene main camera
         SceneCamera =
             Cast<ARRCamera>(URRUObjectUtils::SpawnSimActor(GetWorld(),
-                                                        SceneInstanceId,
-                                                        ARRCamera::StaticClass(),
-                                                        TEXT("RapyutaCamera"),
-                                                        FString::Printf(TEXT("%d_SceneCamera"), SceneInstanceId),
-                                                        FTransform(SceneInstanceLocation),
-                                                        ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn));
-
+                                                           SceneInstanceId,
+                                                           ARRCamera::StaticClass(),
+                                                           TEXT("RapyutaCamera"),
+                                                           FString::Printf(TEXT("%d_SceneCamera"), SceneInstanceId),
+                                                           FTransform(SceneInstanceLocation),
+                                                           ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn));
     }
-    else 
+    else
     {
-        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("GameState is not child class of ARRGameState. Can't use MainFloor, MainWall and Camera."));
+        UE_LOG_WITH_INFO(LogRapyutaCore,
+                         Warning,
+                         TEXT("GameState is not child class of ARRGameState. Can't use MainFloor, MainWall and Camera."));
     }
 #endif
 }
 
 bool URRActorCommon::HasInitialized(bool bIsLogged) const
 {
-
     if (false == GetWorld()->IsNetMode(ENetMode::NM_Standalone))
     {
         return true;

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRBaseActor.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRBaseActor.cpp
@@ -45,17 +45,11 @@ void ARRBaseActor::PreInitializeComponents()
     // SETUP + CONFIGURE GAME & SIM COMMON OBJECTS
     // NOTE: These are used ONLY for dynamic runtime actors.
     // In child BP actors, except for GameSingleton, other Game framework entities maybe not available yet
-#if RAPYUTA_USE_SCENE_DIRECTOR
+
+    // pointers for convinence
     RRGameState = URRCoreUtils::GetGameState<ARRGameState>(this);
-    check(RRGameState)
-#endif
-        RRROS2GameMode = URRCoreUtils::GetGameMode<ARRROS2GameMode>(this);
-
-    if (IsNetMode(NM_Standalone))
-    {
-        RRPlayerController = URRCoreUtils::GetPlayerController<ARRPlayerController>(SceneInstanceId, this);
-    }
-
+    RRPlayerController = URRCoreUtils::GetPlayerController<ARRPlayerController>(SceneInstanceId, this);
+    RRGameMode = URRCoreUtils::GetGameMode<ARRGameMode>(this);
     RRGameSingleton = URRGameSingleton::Get();
     if (RRGameSingleton == nullptr)
     {

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRBaseActor.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRBaseActor.cpp
@@ -42,17 +42,25 @@ void ARRBaseActor::PreInitializeComponents()
 {
     Super::PreInitializeComponents();
 
-    // SETUP + CONFIGURE ESSENTIAL GAME & SIM COMMON OBJECTS
+    // SETUP + CONFIGURE GAME & SIM COMMON OBJECTS
     // NOTE: These are used ONLY for dynamic runtime actors.
     // In child BP actors, except for GameSingleton, other Game framework entities maybe not available yet
 #if RAPYUTA_USE_SCENE_DIRECTOR
-    GameState = URRCoreUtils::GetGameState<ARRGameState>(this);
-    check(GameState)
+    RRGameState = URRCoreUtils::GetGameState<ARRGameState>(this);
+    check(RRGameState)
 #endif
-    GameSingleton = URRGameSingleton::Get();
-    if(GameSingleton==nullptr)
+        RRROS2GameMode = URRCoreUtils::GetGameMode<ARRROS2GameMode>(this);
+
+    if (IsNetMode(NM_Standalone))
     {
-         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Display, TEXT("GameSingleton is not child class of URRGameSingleton. Cannot use Asset loading."));
+        RRPlayerController = URRCoreUtils::GetPlayerController<ARRPlayerController>(SceneInstanceId, this);
+    }
+
+    RRGameSingleton = URRGameSingleton::Get();
+    if (RRGameSingleton == nullptr)
+    {
+        UE_LOG_WITH_INFO_NAMED(
+            LogRapyutaCore, Display, TEXT("GameSingleton is not child class of URRGameSingleton. Cannot use Asset loading."));
     }
 }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRBaseActor.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRBaseActor.cpp
@@ -5,7 +5,6 @@
 #include "Core/RRActorCommon.h"
 #include "Core/RRCoreUtils.h"
 #include "Core/RRGameMode.h"
-#include "Core/RRGameSingleton.h"
 #include "Core/RRGameState.h"
 #include "Core/RRPlayerController.h"
 #include "Core/RRUObjectUtils.h"
@@ -46,16 +45,15 @@ void ARRBaseActor::PreInitializeComponents()
     // SETUP + CONFIGURE ESSENTIAL GAME & SIM COMMON OBJECTS
     // NOTE: These are used ONLY for dynamic runtime actors.
     // In child BP actors, except for GameSingleton, other Game framework entities maybe not available yet
-    GameMode = URRCoreUtils::GetGameMode<ARRGameMode>(this);
+#if RAPYUTA_USE_SCENE_DIRECTOR
     GameState = URRCoreUtils::GetGameState<ARRGameState>(this);
-
-    if (IsNetMode(NM_Standalone))
-    {
-        PlayerController = URRCoreUtils::GetPlayerController<ARRPlayerController>(SceneInstanceId, this);
-    }
-
+    check(GameState)
+#endif
     GameSingleton = URRGameSingleton::Get();
-    check(GameSingleton);
+    if(GameSingleton==nullptr)
+    {
+         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Display, TEXT("GameSingleton is not child class of URRGameSingleton. Cannot use Asset loading."));
+    }
 }
 
 bool ARRBaseActor::Initialize()

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameInstance.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameInstance.cpp
@@ -11,28 +11,36 @@
 FString URRGameInstance::SMapName;
 void URRGameInstance::PreloadContentForURL(FURL InURL)
 {
+#if RAPYUTA_SIM_DEBUG
     UE_LOG(LogRapyutaCore, Display, TEXT("Preload Content for Map [%s]"), *InURL.Map)
+#endif
     Super::PreloadContentForURL(InURL);
 }
 
 AGameModeBase* URRGameInstance::CreateGameModeForURL(FURL InURL, UWorld* InWorld)
 {
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT(" URL MAP PATH [%s] loaded into WORLD [%s]"), *InURL.Map, *InWorld->GetName());
 
     SMapName = InWorld->GetName();
+#if RAPYUTA_SIM_DEBUG
+    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT(" URL MAP PATH [%s] loaded into WORLD [%s]"), *InURL.Map, *InWorld->GetName());
     URRCoreUtils::ScreenMsg(FColor::Yellow, FString::Printf(TEXT("MAP: %s"), *SMapName));
+#endif
     return Super::CreateGameModeForURL(InURL, InWorld);
 }
 
 void URRGameInstance::StartGameInstance()
 {
+#if RAPYUTA_SIM_DEBUG
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("StartGameInstance!"));
+#endif
     Super::StartGameInstance();
 }
 
 void URRGameInstance::Init()
 {
+#if RAPYUTA_SIM_DEBUG
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("INIT!"))
+#endif
     Super::Init();
     URRMathUtils::InitializeRandomStream();
 }
@@ -40,11 +48,15 @@ void URRGameInstance::Init()
 void URRGameInstance::LoadComplete(const float InLoadTime, const FString& InMapName)
 {
     Super::LoadComplete(InLoadTime, InMapName);
+#if RAPYUTA_SIM_DEBUG
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("[%s] LOADING COMPLETED!"), *InMapName);
+#endif
 }
 
 void URRGameInstance::OnStart()
 {
+#if RAPYUTA_SIM_DEBUG
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("ON START!"))
+#endif
     Super::OnStart();
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameInstance.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameInstance.cpp
@@ -11,7 +11,7 @@
 FString URRGameInstance::SMapName;
 void URRGameInstance::PreloadContentForURL(FURL InURL)
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG(LogRapyutaCore, Display, TEXT("Preload Content for Map [%s]"), *InURL.Map)
 #endif
     Super::PreloadContentForURL(InURL);
@@ -19,9 +19,8 @@ void URRGameInstance::PreloadContentForURL(FURL InURL)
 
 AGameModeBase* URRGameInstance::CreateGameModeForURL(FURL InURL, UWorld* InWorld)
 {
-
     SMapName = InWorld->GetName();
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT(" URL MAP PATH [%s] loaded into WORLD [%s]"), *InURL.Map, *InWorld->GetName());
     URRCoreUtils::ScreenMsg(FColor::Yellow, FString::Printf(TEXT("MAP: %s"), *SMapName));
 #endif
@@ -30,7 +29,7 @@ AGameModeBase* URRGameInstance::CreateGameModeForURL(FURL InURL, UWorld* InWorld
 
 void URRGameInstance::StartGameInstance()
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("StartGameInstance!"));
 #endif
     Super::StartGameInstance();
@@ -38,7 +37,7 @@ void URRGameInstance::StartGameInstance()
 
 void URRGameInstance::Init()
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("INIT!"))
 #endif
     Super::Init();
@@ -48,14 +47,14 @@ void URRGameInstance::Init()
 void URRGameInstance::LoadComplete(const float InLoadTime, const FString& InMapName)
 {
     Super::LoadComplete(InLoadTime, InMapName);
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("[%s] LOADING COMPLETED!"), *InMapName);
 #endif
 }
 
 void URRGameInstance::OnStart()
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("ON START!"))
 #endif
     Super::OnStart();

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameMode.cpp
@@ -17,14 +17,16 @@
 
 ARRGameMode::ARRGameMode()
 {
+#if RAPYUTA_USE_SCENE_DIRECTOR
     GameStateClass = ARRGameState::StaticClass();
     PlayerControllerClass = ARRPlayerController::StaticClass();
+#endif
 }
 
 void ARRGameMode::PreInitializeComponents()
 {
 #if RAPYUTA_SIM_DEBUG
-    UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("PreInitializeComponents()"))
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("PreInitializeComponents()"))
 #endif
     Super::PreInitializeComponents();
 }
@@ -32,46 +34,46 @@ void ARRGameMode::PreInitializeComponents()
 void ARRGameMode::InitGameState()
 {
 #if RAPYUTA_SIM_DEBUG
-    UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("InitGameState()"));
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("InitGameState()"));
 #endif
     Super::InitGameState();
 }
 
 void ARRGameMode::PrintSimConfig() const
 {
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("SIM GAME MODE CONFIG -----------------------------"));
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("- bBenchmark: %d"), bBenchmark);
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("SIM GAME MODE CONFIG -----------------------------"));
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("- bBenchmark: %d"), bBenchmark);
 }
 
 void ARRGameMode::PrintUEPreprocessors() const
 {
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("UE PREPROCESSORS:"));
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("* [DO_CHECK] %s!"), URRCoreUtils::GetBoolPreprocessorText<DO_CHECK>());
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("UE PREPROCESSORS:"));
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("* [DO_CHECK] %s!"), URRCoreUtils::GetBoolPreprocessorText<DO_CHECK>());
 
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("* [STATS] %s!"), URRCoreUtils::GetBoolPreprocessorText<STATS>());
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("* [STATS] %s!"), URRCoreUtils::GetBoolPreprocessorText<STATS>());
 
     UE_LOG_WITH_INFO(LogRapyutaCore,
-                     Display,
+                     Verbose,
                      TEXT("* [CPUPROFILERTRACE_ENABLED] (for UE Insights) %s!"),
                      URRCoreUtils::GetBoolPreprocessorText<CPUPROFILERTRACE_ENABLED>());
 
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("* [WITH_EDITOR] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_EDITOR>());
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("* [WITH_EDITOR] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_EDITOR>());
 
     UE_LOG_WITH_INFO(LogRapyutaCore,
-                     Display,
+                     Verbose,
                      TEXT("* [RHI_RAYTRACING] %s %d!"),
                      URRCoreUtils::GetBoolPreprocessorText<RHI_RAYTRACING>(),
                      IsRayTracingEnabled());
 
     UE_LOG_WITH_INFO(
-        LogRapyutaCore, Display, TEXT("* [WITH_UNREALPNG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALPNG>());
+        LogRapyutaCore, Verbose, TEXT("* [WITH_UNREALPNG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALPNG>());
 
     UE_LOG_WITH_INFO(
-        LogRapyutaCore, Display, TEXT("* [WITH_UNREALJPEG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALJPEG>());
+        LogRapyutaCore, Verbose, TEXT("* [WITH_UNREALJPEG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALJPEG>());
 
 #if (!WITH_EDITOR)
     UE_LOG_WITH_INFO(LogRapyutaCore,
-                     Display,
+                     Verbose,
                      TEXT("- bAsyncLoadingThreadEnabled: %d"),
                      FAsyncLoadingThreadSettings::Get().bAsyncLoadingThreadEnabled);
 #endif
@@ -82,16 +84,16 @@ void ARRGameMode::PrintUEPreprocessors() const
     if (PhysSingleThreadedMode())
     {
         // UnrealEngine/Engine/Source/Runtime/Engine/Private/PhysicsEngine/PhysScene_PhysX.cpp:1519
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN GAME THREAD!"));
+        UE_LOG_WITH_INFO(LogTemp, Verbose, TEXT("PHYSICS RUNS IN GAME THREAD!"));
     }
     else if (URRCoreUtils::GetCommandLineArgumentValue<int8>(URRCoreUtils::CCMDLINE_ARG_INT_PHYSX_DISPATCHER_NUM,
                                                              physXDispatcherNum))
     {
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN [%d] THREADS!"), physXDispatcherNum);
+        UE_LOG_WITH_INFO(LogTemp, Verbose, TEXT("PHYSICS RUNS IN [%d] THREADS!"), physXDispatcherNum);
     }
     else
     {
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN A SINGLE THREAD!"));
+        UE_LOG_WITH_INFO(LogTemp, Verbose, TEXT("PHYSICS RUNS IN A SINGLE THREAD!"));
     }
 }
 
@@ -115,8 +117,11 @@ void ARRGameMode::StartPlay()
     PrintSimConfig();
     PrintUEPreprocessors();
 
-    GameInstance = Cast<URRGameInstance>(GetGameInstance());
-    verify(GameInstance);
+    if(URRGameSingleton::Get()==nullptr)
+    {
+        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("GameSingleton is not child class of0 URRGameSingleton."));
+    }
+
 
 #if !WITH_EDITOR
     FApp::SetBenchmarking(bBenchmark);
@@ -128,9 +133,9 @@ void ARRGameMode::StartPlay()
     // Call after the benchmark to apply settings to running game
     UGameUserSettings::GetGameUserSettings()->ApplyHardwareBenchmarkResults();
 #endif
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("Is bench marking: %d"), FApp::IsBenchmarking());
+    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("Is bench marking: %d"), FApp::IsBenchmarking());
     UE_LOG_WITH_INFO(
-        LogRapyutaCore, Display, TEXT("Use Fixed time step: %d %f"), FApp::UseFixedTimeStep(), FApp::GetFixedDeltaTime());
+        LogRapyutaCore, Verbose, TEXT("Use Fixed time step: %d %f"), FApp::UseFixedTimeStep(), FApp::GetFixedDeltaTime());
 
     // 1- CONFIGURE GAME GLOBALLY
     ConfigureSimInPlay();
@@ -149,7 +154,11 @@ void ARRGameMode::StartSim()
     URRCoreUtils::LoadImageWrapperModule();
 
     // 2- LOAD SIM STATIC GLOBAL RESOURCES --
-    URRGameSingleton::Get()->InitializeResources();
+    auto* gameSingleton = URRGameSingleton::Get();
+    if(gameSingleton)
+    {
+        gameSingleton->InitializeResources();
+    }
 
     // 3- START SIM ONCE RESOURCES ARE LOADED --
     //
@@ -167,27 +176,33 @@ bool ARRGameMode::TryStartingSim()
     // !NOTE: This method was scheduled to be run by BeginPlay()
     // 1 - WAIT FOR RESOURCE LOADING, in prep for Sim initialization
     UWorld* world = GetWorld();
-    bool bResult = URRCoreUtils::CheckWithTimeOut(
-        []() { return URRGameSingleton::Get()->HaveAllResourcesBeenLoaded(); },
-        [this, world]()
-        {
-            // Clear the timer to avoid repeated call to the method
-            URRCoreUtils::StopRegisteredTimer(world, OwnTimerHandle);
-            UE_LOG_WITH_INFO(LogRapyutaCore, Fatal, TEXT("DYNAMIC RESOURCES LOADING TIMEOUT -> SHUTTING DOWN THE SIM..."))
-        },
-        sBeginTime,
-        ARRGameMode::SIM_START_TIMEOUT_SECS);
-
-    // Either resources have yet to be fully loaded or time out!
-    if (!bResult)
+    
+    auto* gameSingleton = URRGameSingleton::Get();
+    if(gameSingleton)
     {
-        return false;
+        bool bResult = URRCoreUtils::CheckWithTimeOut(
+            [gameSingleton]() { return gameSingleton->HaveAllResourcesBeenLoaded(); },
+            [this, world]()
+            {
+                // Clear the timer to avoid repeated call to the method
+                URRCoreUtils::StopRegisteredTimer(world, OwnTimerHandle);
+                UE_LOG_WITH_INFO(LogRapyutaCore, Fatal, TEXT("DYNAMIC RESOURCES LOADING TIMEOUT -> SHUTTING DOWN THE SIM..."))
+            },
+            sBeginTime,
+            ARRGameMode::SIM_START_TIMEOUT_SECS);
+
+        // Either resources have yet to be fully loaded or time out!
+        if (!bResult)
+        {
+            return false;
+        }
     }
+
     // Clear the timer to avoid repeated call to the method
     URRCoreUtils::StopRegisteredTimer(world, OwnTimerHandle);
 
     URRCoreUtils::ScreenMsg(FColor::Yellow, TEXT("ALL DYNAMIC RESOURCES LOADED!"), 10.f);
-    UE_LOG(LogRapyutaCore, Display, TEXT("ALL DYNAMIC RESOURCES LOADED! -> BRING UP THE SIM NOW... ========================"));
+    UE_LOG(LogRapyutaCore, Verbose, TEXT("ALL DYNAMIC RESOURCES LOADED! -> BRING UP THE SIM NOW... ========================"));
 
     // 1 - [GameState]::StartSim()
     auto gameState = GetGameState<ARRGameState>();
@@ -197,9 +212,17 @@ bool ARRGameMode::TryStartingSim()
         return false;
     }
     gameState->StartSim();
-    UE_LOG(LogRapyutaCore, Display, TEXT("SIM STARTED, SIM SCENE'S ACTORS ARE ACCESSIBLE NOW! ========================"))
+    UE_LOG(LogRapyutaCore, Verbose, TEXT("SIM STARTED, SIM SCENE'S ACTORS ARE ACCESSIBLE NOW! ========================"))
 
     // 2- START PARENT'S PLAY, WHICH TRIGGER OTHERS PLAY FROM GAME STATE, PLAYER CONTROLLER, ETC.
     ARRROS2GameMode::StartPlay();
     return true;
+}
+
+void ARRGameMode::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    // 1 - These resources were initialized in [ARRGameMode::StartPlay()], which does not have a corresponding EndPlay()
+    URRGameSingleton::Get()->FinalizeResources();
+
+    Super::EndPlay(EndPlayReason);
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameMode.cpp
@@ -157,6 +157,9 @@ void ARRGameMode::StartSim()
     auto* gameSingleton = URRGameSingleton::Get();
     if (gameSingleton)
     {
+#if RAPYUTA_SIM_VERBOSE
+        gameSingleton->PrintSimConfig();
+#endif
         gameSingleton->InitializeResources();
     }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameMode.cpp
@@ -25,7 +25,7 @@ ARRGameMode::ARRGameMode()
 
 void ARRGameMode::PreInitializeComponents()
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("PreInitializeComponents()"))
 #endif
     Super::PreInitializeComponents();
@@ -33,47 +33,47 @@ void ARRGameMode::PreInitializeComponents()
 
 void ARRGameMode::InitGameState()
 {
-#if RAPYUTA_SIM_DEBUG
-    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("InitGameState()"));
+#if RAPYUTA_SIM_VERBOSE
+    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("InitGameState()"));
 #endif
     Super::InitGameState();
 }
 
 void ARRGameMode::PrintSimConfig() const
 {
-    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("SIM GAME MODE CONFIG -----------------------------"));
-    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("- bBenchmark: %d"), bBenchmark);
+    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("SIM GAME MODE CONFIG -----------------------------"));
+    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("- bBenchmark: %d"), bBenchmark);
 }
 
 void ARRGameMode::PrintUEPreprocessors() const
 {
-    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("UE PREPROCESSORS:"));
-    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("* [DO_CHECK] %s!"), URRCoreUtils::GetBoolPreprocessorText<DO_CHECK>());
+    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("UE PREPROCESSORS:"));
+    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("* [DO_CHECK] %s!"), URRCoreUtils::GetBoolPreprocessorText<DO_CHECK>());
 
-    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("* [STATS] %s!"), URRCoreUtils::GetBoolPreprocessorText<STATS>());
+    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("* [STATS] %s!"), URRCoreUtils::GetBoolPreprocessorText<STATS>());
 
     UE_LOG_WITH_INFO(LogRapyutaCore,
-                     Verbose,
+                     Display,
                      TEXT("* [CPUPROFILERTRACE_ENABLED] (for UE Insights) %s!"),
                      URRCoreUtils::GetBoolPreprocessorText<CPUPROFILERTRACE_ENABLED>());
 
-    UE_LOG_WITH_INFO(LogRapyutaCore, Verbose, TEXT("* [WITH_EDITOR] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_EDITOR>());
+    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("* [WITH_EDITOR] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_EDITOR>());
 
     UE_LOG_WITH_INFO(LogRapyutaCore,
-                     Verbose,
+                     Display,
                      TEXT("* [RHI_RAYTRACING] %s %d!"),
                      URRCoreUtils::GetBoolPreprocessorText<RHI_RAYTRACING>(),
                      IsRayTracingEnabled());
 
     UE_LOG_WITH_INFO(
-        LogRapyutaCore, Verbose, TEXT("* [WITH_UNREALPNG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALPNG>());
+        LogRapyutaCore, Display, TEXT("* [WITH_UNREALPNG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALPNG>());
 
     UE_LOG_WITH_INFO(
-        LogRapyutaCore, Verbose, TEXT("* [WITH_UNREALJPEG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALJPEG>());
+        LogRapyutaCore, Display, TEXT("* [WITH_UNREALJPEG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALJPEG>());
 
 #if (!WITH_EDITOR)
     UE_LOG_WITH_INFO(LogRapyutaCore,
-                     Verbose,
+                     Display,
                      TEXT("- bAsyncLoadingThreadEnabled: %d"),
                      FAsyncLoadingThreadSettings::Get().bAsyncLoadingThreadEnabled);
 #endif
@@ -84,16 +84,16 @@ void ARRGameMode::PrintUEPreprocessors() const
     if (PhysSingleThreadedMode())
     {
         // UnrealEngine/Engine/Source/Runtime/Engine/Private/PhysicsEngine/PhysScene_PhysX.cpp:1519
-        UE_LOG_WITH_INFO(LogTemp, Verbose, TEXT("PHYSICS RUNS IN GAME THREAD!"));
+        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN GAME THREAD!"));
     }
     else if (URRCoreUtils::GetCommandLineArgumentValue<int8>(URRCoreUtils::CCMDLINE_ARG_INT_PHYSX_DISPATCHER_NUM,
                                                              physXDispatcherNum))
     {
-        UE_LOG_WITH_INFO(LogTemp, Verbose, TEXT("PHYSICS RUNS IN [%d] THREADS!"), physXDispatcherNum);
+        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN [%d] THREADS!"), physXDispatcherNum);
     }
     else
     {
-        UE_LOG_WITH_INFO(LogTemp, Verbose, TEXT("PHYSICS RUNS IN A SINGLE THREAD!"));
+        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN A SINGLE THREAD!"));
     }
 }
 
@@ -112,16 +112,16 @@ void ARRGameMode::ConfigureSimInPlay()
 
 void ARRGameMode::StartPlay()
 {
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("START PLAY!"))
-
     PrintSimConfig();
     PrintUEPreprocessors();
+#endif
 
-    if(URRGameSingleton::Get()==nullptr)
+    if (URRGameSingleton::Get() == nullptr)
     {
         UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("GameSingleton is not child class of0 URRGameSingleton."));
     }
-
 
 #if !WITH_EDITOR
     FApp::SetBenchmarking(bBenchmark);
@@ -155,7 +155,7 @@ void ARRGameMode::StartSim()
 
     // 2- LOAD SIM STATIC GLOBAL RESOURCES --
     auto* gameSingleton = URRGameSingleton::Get();
-    if(gameSingleton)
+    if (gameSingleton)
     {
         gameSingleton->InitializeResources();
     }
@@ -176,9 +176,9 @@ bool ARRGameMode::TryStartingSim()
     // !NOTE: This method was scheduled to be run by BeginPlay()
     // 1 - WAIT FOR RESOURCE LOADING, in prep for Sim initialization
     UWorld* world = GetWorld();
-    
+
     auto* gameSingleton = URRGameSingleton::Get();
-    if(gameSingleton)
+    if (gameSingleton)
     {
         bool bResult = URRCoreUtils::CheckWithTimeOut(
             [gameSingleton]() { return gameSingleton->HaveAllResourcesBeenLoaded(); },

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -21,7 +21,7 @@ TMap<ERRResourceDataType, TArray<const TCHAR*>> URRGameSingleton::SASSET_OWNING_
 
 URRGameSingleton::URRGameSingleton()
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("INSTANTIATED! ======================"));
 #endif
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -21,7 +21,9 @@ TMap<ERRResourceDataType, TArray<const TCHAR*>> URRGameSingleton::SASSET_OWNING_
 
 URRGameSingleton::URRGameSingleton()
 {
+#if RAPYUTA_SIM_DEBUG
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("INSTANTIATED! ======================"));
+#endif
 }
 
 URRGameSingleton::~URRGameSingleton()
@@ -39,7 +41,7 @@ URRGameSingleton* URRGameSingleton::Get()
     URRGameSingleton* singleton = Cast<URRGameSingleton>(GEngine->GameSingleton);
     if (!singleton)
     {
-        UE_LOG_WITH_INFO(LogRapyutaCore, Fatal, TEXT("NOT YET SET AS GAME SINGLETON!!"));
+        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("NOT YET SET AS GAME SINGLETON!!"));
         return nullptr;
     }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
@@ -12,7 +12,6 @@
 // RapyutaSimulationPlugins
 #include "Core/RRActorCommon.h"
 #include "Core/RRCoreUtils.h"
-#include "Core/RRGameInstance.h"
 #include "Core/RRMathUtils.h"
 #include "Core/RRMeshActor.h"
 #include "Core/RRPlayerController.h"
@@ -52,21 +51,20 @@ void ARRGameState::StartSim()
 {
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("[Start Sim with Num of SceneInstances: %d]"), SCENE_INSTANCES_NUM);
 
-    URRGameSingleton::Get()->PrintSimConfig();
     PrintSimConfig();
 
     GameMode = URRCoreUtils::GetGameMode<ARRGameMode>(this);
     check(GameMode);
 
-    GameInstance = URRCoreUtils::GetGameInstance<URRGameInstance>(this);
-    check(GameInstance);
-
     // Each Sim scene instance has a Player Controller on its own, the max number of which is defined by
     // [UGameViewportClient::MaxSplitscreenPlayers]
     const int32 maxSplitscreenPlayers = URRCoreUtils::GetMaxSplitscreenPlayers(this);
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("MAX SPLIT SCREEN PLAYERS: %d"), maxSplitscreenPlayers);
-    verify(SCENE_INSTANCES_NUM <= maxSplitscreenPlayers);
-
+    if(SCENE_INSTANCES_NUM > maxSplitscreenPlayers)
+    {
+        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("SCENE_INSTANCE_NUM > MAX SPLIT SCREEN PLAYERS, SCENE_INSTANCE_NUM set to MAX SPLIT SCREEN PLAYERS: %d"), maxSplitscreenPlayers);
+        SCENE_INSTANCES_NUM = maxSplitscreenPlayers;
+    }
+    
     // 0- Stream level & Fetch static-env actors
     SetupEnvironment();
 
@@ -116,10 +114,20 @@ void ARRGameState::FetchEnvStaticActors()
 
 void ARRGameState::CreateSceneInstance(int8 InSceneInstanceId)
 {
-    verify(InSceneInstanceId >= 0);
+    if (InSceneInstanceId < 0)
+    {
+        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Given SceneInstance is %d. SceneInstancId must > 0. Set to 0."), InSceneInstanceId);
+        
+        InSceneInstanceId = 0;
+    }
     URRSceneInstance* newSceneInstance = Cast<URRSceneInstance>(URRUObjectUtils::CreateSelfSubobject(
-        this, SceneInstanceClass, FString::Printf(TEXT("%d_%s"), InSceneInstanceId, *URRGameInstance::SMapName)));
-    verify(newSceneInstance);
+        this, SceneInstanceClass, FString::Printf(TEXT("%d_%s"), InSceneInstanceId, *GetWorld()->GetName())));
+    if(newSceneInstance == nullptr)
+    {
+        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Failed to create SceneInstance"));
+        return;
+    }
+
     newSceneInstance->ConfigureStaticClasses();
     SceneInstanceList.Add(newSceneInstance);
 
@@ -285,9 +293,6 @@ void ARRGameState::EndPlay(const EEndPlayReason::Type EndPlayReason)
     // 2 - Clear and reset Sim [static] contents (like ~FunctionLibrary's static ~Common object handles, due to not managed by UE
     // UObject system)
     FinalizeSim();
-
-    // 3 - These resources were initialized in [ARRGameMode::StartPlay()], which does not have a corresponding EndPlay()
-    URRGameSingleton::Get()->FinalizeResources();
 
     Super::EndPlay(EndPlayReason);
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameState.cpp
@@ -54,17 +54,20 @@ void ARRGameState::StartSim()
     PrintSimConfig();
 
     GameMode = URRCoreUtils::GetGameMode<ARRGameMode>(this);
-    check(GameMode);
 
     // Each Sim scene instance has a Player Controller on its own, the max number of which is defined by
     // [UGameViewportClient::MaxSplitscreenPlayers]
     const int32 maxSplitscreenPlayers = URRCoreUtils::GetMaxSplitscreenPlayers(this);
-    if(SCENE_INSTANCES_NUM > maxSplitscreenPlayers)
+    if (SCENE_INSTANCES_NUM > maxSplitscreenPlayers)
     {
-        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("SCENE_INSTANCE_NUM > MAX SPLIT SCREEN PLAYERS, SCENE_INSTANCE_NUM set to MAX SPLIT SCREEN PLAYERS: %d"), maxSplitscreenPlayers);
+        UE_LOG_WITH_INFO(
+            LogRapyutaCore,
+            Warning,
+            TEXT("SCENE_INSTANCE_NUM > MAX SPLIT SCREEN PLAYERS, SCENE_INSTANCE_NUM set to MAX SPLIT SCREEN PLAYERS: %d"),
+            maxSplitscreenPlayers);
         SCENE_INSTANCES_NUM = maxSplitscreenPlayers;
     }
-    
+
     // 0- Stream level & Fetch static-env actors
     SetupEnvironment();
 
@@ -116,13 +119,14 @@ void ARRGameState::CreateSceneInstance(int8 InSceneInstanceId)
 {
     if (InSceneInstanceId < 0)
     {
-        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Given SceneInstance is %d. SceneInstancId must > 0. Set to 0."), InSceneInstanceId);
-        
+        UE_LOG_WITH_INFO(
+            LogRapyutaCore, Warning, TEXT("Given SceneInstance is %d. SceneInstancId must > 0. Set to 0."), InSceneInstanceId);
+
         InSceneInstanceId = 0;
     }
     URRSceneInstance* newSceneInstance = Cast<URRSceneInstance>(URRUObjectUtils::CreateSelfSubobject(
         this, SceneInstanceClass, FString::Printf(TEXT("%d_%s"), InSceneInstanceId, *GetWorld()->GetName())));
-    if(newSceneInstance == nullptr)
+    if (newSceneInstance == nullptr)
     {
         UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Failed to create SceneInstance"));
         return;

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRMeshActor.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRMeshActor.cpp
@@ -105,7 +105,7 @@ void ARRMeshActor::SetCustomDepthEnabled(bool bIsCustomDepthEnabled)
         // Since deactivated actors do not appear in scene so their custom depth stencil values should be reused
         if (bIsCustomDepthEnabled && IsDataSynthEntity())
         {
-            auto* sceneDirector = GameState->GetSceneInstance<URRSceneInstance>(SceneInstanceId)->SceneDirector;
+            auto* sceneDirector = RRGameState->GetSceneInstance<URRSceneInstance>(SceneInstanceId)->SceneDirector;
             meshComp->SetCustomDepthStencilValue((sceneDirector->SceneEntityMaskValueList.Num() > 0)
                                                      ? sceneDirector->SceneEntityMaskValueList.Pop()
                                                      : ActorCommon->GenerateUniqueDepthStencilValue());
@@ -128,7 +128,7 @@ void ARRMeshActor::SetCustomDepthStencilValue(int32 InCustomDepthStencilValue)
         // [CustomDepthStencilValue]
         if (bCustomDepthEnabled && IsDataSynthEntity())
         {
-            auto* sceneDirector = GameState->GetSceneInstance<URRSceneInstance>(SceneInstanceId)->SceneDirector;
+            auto* sceneDirector = RRGameState->GetSceneInstance<URRSceneInstance>(SceneInstanceId)->SceneDirector;
             meshComp->SetCustomDepthStencilValue(InCustomDepthStencilValue);
         }
         else

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRMeshActor.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRMeshActor.cpp
@@ -177,7 +177,7 @@ void ARRMeshActor::DeclareFullCreation(bool bInCreationResult)
     bFullyCreated = bInCreationResult;
     if (bInCreationResult)
     {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("[%s] MESH ACTOR CREATED!"));
 #endif
     }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRNetworkPlayerController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRNetworkPlayerController.cpp
@@ -90,7 +90,6 @@ void ARRNetworkPlayerController::ClientInitSimStateClientROS2_Implementation()
     SimStateClientROS2Node->Init();
 
     // Init [ROS2SimStateClient] with [SimStateClientROS2Node]
-    check(ROS2SimStateClient);
     ROS2SimStateClient->Init(SimStateClientROS2Node);
 
     // Create Clock publisher

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRPlayerController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRPlayerController.cpp
@@ -35,14 +35,11 @@ void ARRPlayerController::BeginPlay()
 
 bool ARRPlayerController::Initialize()
 {
-    if (false == IsNetMode(NM_Standalone) ||
-        nullptr == GameMode ||
-        !GameMode->IsDataSynthSimType()
-        )
+    if (false == IsNetMode(NM_Standalone) || nullptr == GameMode || !GameMode->IsDataSynthSimType())
     {
         return true;
     }
-    
+
 #if RAPYUTA_USE_SCENE_DIRECTOR
     verify(GameState->HasInitialized(true));
     verify(GameState->HasSceneInstance(SceneInstanceId));
@@ -56,10 +53,13 @@ bool ARRPlayerController::Initialize()
 
     SceneCamera = ActorCommon->SceneCamera;
     check(SceneCamera);
-    Possess(SceneCamera);
+    if (GameMode->IsDataSynthSimType())
+    {
+        Possess(SceneCamera);
+    }
     // Not all maps has GlobalPostProcessVolume
     MainPostProcessVolume = Cast<APostProcessVolume>(URRUObjectUtils::FindPostProcessVolume(GetWorld()));
-#endif    
+#endif
 
     return true;
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRProceduralMeshComponent.cpp
@@ -119,7 +119,8 @@ bool URRProceduralMeshComponent::CreateMeshBody(const FRRMeshData& InBodyMeshDat
     }
 
     ARRMeshActor* ownerActor = CastChecked<ARRMeshActor>(GetOwner());
-    if (false == ownerActor->GameMode->IsDataSynthSimType())
+    auto* gameMode = URRCoreUtils::GetGameMode<ARRGameMode>(this);
+    if (gameMode && false == gameMode->IsDataSynthSimType())
     {
         for (auto i = 0; i < InBodyMeshData.MaterialInstances.Num(); ++i)
         {

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRROS2GameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRROS2GameMode.cpp
@@ -74,7 +74,11 @@ void ARRROS2GameMode::InitROS2()
     MainROS2Node = UROS2NodeComponent::CreateNewNode(this, MainROS2NodeName, TEXT("/"));
 
     // MainSimState
-    check(MainSimState);
+    if(MainSimState == nullptr)
+    {
+        UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("Failed to create ROS2Node."));
+        return;
+    }
 
     // MainROS2SimStateClient
     MainROS2SimStateClient = NewObject<URRROS2SimulationStateClient>(this, ROS2SimStateClientClass, TEXT("MainROS2SimStateClient"));

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRROS2GameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRROS2GameMode.cpp
@@ -76,7 +76,7 @@ void ARRROS2GameMode::InitROS2()
     // MainSimState
     if(MainSimState == nullptr)
     {
-        UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("Failed to create ROS2Node."));
+        UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("Failed to create MainSimState."));
         return;
     }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
@@ -66,7 +66,7 @@ void ARRSceneDirector::TryInitializeOperation()
 
 bool ARRSceneDirector::InitializeOperation()
 {
-    OperationBatchLoopLeft = GameState->OPERATION_BATCHES_NUM;
+    OperationBatchLoopLeft = RRGameState->OPERATION_BATCHES_NUM;
     OperationBatchId = 1;
 
     // Plugin common objects (which should be valid only after Sim has initialized) --

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
@@ -38,7 +38,7 @@ void URRStaticMeshComponent::BeginPlay()
 
 void URRStaticMeshComponent::Initialize(bool bInIsStationary, bool bInIsPhysicsEnabled)
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO_NAMED(LogRapyutaCore,
                            Warning,
                            TEXT("STATIC MESH COMP INITIALIZED - Stationary: %d Physics Enabled: %d!"),
@@ -271,7 +271,7 @@ void URRStaticMeshComponent::CreateMeshSection(const TArray<FRRMeshNodeData>& In
             continue;
         }
 
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
         UE_LOG_WITH_INFO_NAMED(
             LogRapyutaCore,
             Warning,

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
@@ -236,7 +236,7 @@ ARRBaseActor* URRUObjectUtils::SpawnSimActor(UWorld* InWorld,
     if (newActor)
     {
         // This is set in ctor
-        verify(newActor->SceneInstanceId == InSceneInstanceId);
+        ensure(newActor->SceneInstanceId == InSceneInstanceId);
         newActor->SetEntityModelName(InEntityModelName);
 
 #if WITH_EDITOR
@@ -246,7 +246,7 @@ ARRBaseActor* URRUObjectUtils::SpawnSimActor(UWorld* InWorld,
 #endif
 
         // Initializing itself
-        verify(newActor->Initialize());
+        ensure(newActor->Initialize());
     }
     else
     {

--- a/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
@@ -247,7 +247,7 @@ void URobotVehicleMovementComponent::InitData()
     {
         ContactPoints.Add(Cast<USceneComponent>(acp));
     }
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Nb Contact Points : %d"), ContactPoints.Num());
 #endif
 
@@ -272,7 +272,7 @@ void URobotVehicleMovementComponent::InitData()
     {
         MinDistanceToFloor = hitResult.Distance;
     }
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Min Distance To Floor = %f"), MinDistanceToFloor);
 #endif
 }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -89,21 +89,21 @@ bool ARRBaseRobot::IsAuthorizedInThisClient()
     {
         if (nullptr == ROS2Interface)
         {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
             UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("No ROS2Controller found"));
 #endif
             res = false;
         }
         else if (nullptr == ROS2Interface->ROSSpawnParameters)
         {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
             UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("No ROS2Controller->ROSSpawnParameters found"));
 #endif
             res = false;
         }
         else if (nullptr == npc)
         {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
             UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("No ARRNetworkPlayerController found"));
 #endif
             res = false;
@@ -116,7 +116,7 @@ bool ARRBaseRobot::IsAuthorizedInThisClient()
         }
         else
         {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
             UE_LOG_WITH_INFO_NAMED(LogRapyutaCore,
                                    Warning,
                                    TEXT("PlayerId is mismatched. This robot spawned by PlaeyrId=%d. This Client's PlayerId=%d. "),
@@ -301,9 +301,8 @@ bool ARRBaseRobot::InitMoveComponent()
     if (VehicleMoveComponentClass && MovementComponent == nullptr)
     {
         // (NOTE) Being created in [OnConstruction], PIE will cause this to be reset anyway, thus requires recreation
-        SetMoveComponent(CastChecked<UMovementComponent>(
-            URRUObjectUtils::CreateSelfSubobject(this, VehicleMoveComponentClass, FString::Printf(TEXT("%sMoveComp"), *GetName()))));
-
+        SetMoveComponent(CastChecked<UMovementComponent>(URRUObjectUtils::CreateSelfSubobject(
+            this, VehicleMoveComponentClass, FString::Printf(TEXT("%sMoveComp"), *GetName()))));
 
         UE_LOG_WITH_INFO(LogRapyutaCore,
                          Display,

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
@@ -22,7 +22,9 @@
 
 void URRRobotROS2Interface::Initialize(ARRBaseRobot* InRobot)
 {
-    UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("InitializeROS2Interface"));
+#if RAPYUTA_SIM_DEBUG
+    UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Verbose, TEXT("InitializeROS2Interface"));
+#endif
     if (nullptr == InRobot)
     {
         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("No pawn is given."));
@@ -401,7 +403,13 @@ void URRRobotROS2Interface::JointStateCallback(const UROS2GenericMsg* Msg)
         AsyncTask(ENamedThreads::GameThread,
                   [this, joints, jointControlType]
                   {
-                      check(IsValid(Robot));
+                      if(!IsValid(Robot))
+                      {
+                        UE_LOG_WITH_INFO_NAMED(LogRapyutaCore,
+                                    Warning,
+                                    TEXT("Robot is nullptr. RobotROS2Interface::Robot must not be nullptr."));
+                        return;
+                      }
                       Robot->SetJointState(joints, jointControlType);
                   });
     }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
@@ -22,7 +22,7 @@
 
 void URRRobotROS2Interface::Initialize(ARRBaseRobot* InRobot)
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Verbose, TEXT("InitializeROS2Interface"));
 #endif
     if (nullptr == InRobot)
@@ -171,8 +171,7 @@ bool URRRobotROS2Interface::InitSubscriptions()
     }
 
     // Subscription with callback to enqueue vehicle spawn info.
-    RR_ROBOT_ROS2_SUBSCRIBE_TO_TOPIC(
-        CmdVelTopicName, UROS2TwistMsg::StaticClass(), &URRRobotROS2Interface::MovementCallback);
+    RR_ROBOT_ROS2_SUBSCRIBE_TO_TOPIC(CmdVelTopicName, UROS2TwistMsg::StaticClass(), &URRRobotROS2Interface::MovementCallback);
 
     // Subscription with callback to enqueue vehicle spawn info.
     RR_ROBOT_ROS2_SUBSCRIBE_TO_TOPIC(
@@ -403,12 +402,11 @@ void URRRobotROS2Interface::JointStateCallback(const UROS2GenericMsg* Msg)
         AsyncTask(ENamedThreads::GameThread,
                   [this, joints, jointControlType]
                   {
-                      if(!IsValid(Robot))
+                      if (!IsValid(Robot))
                       {
-                        UE_LOG_WITH_INFO_NAMED(LogRapyutaCore,
-                                    Warning,
-                                    TEXT("Robot is nullptr. RobotROS2Interface::Robot must not be nullptr."));
-                        return;
+                          UE_LOG_WITH_INFO_NAMED(
+                              LogRapyutaCore, Warning, TEXT("Robot is nullptr. RobotROS2Interface::Robot must not be nullptr."));
+                          return;
                       }
                       Robot->SetJointState(joints, jointControlType);
                   });

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RR2DLidarComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RR2DLidarComponent.cpp
@@ -330,8 +330,10 @@ FROSLaserScan URR2DLidarComponent::GetROS2Data()
                                                               FVector::DotProduct(HitSurfaceNormal, -RayDirection),
                                  IntensityNonReflective,
                                  IntensityReflective);
-                check(Intensity >= IntensityNonReflective);
-                check(Intensity <= IntensityReflective);
+                if (Intensity <= IntensityNonReflective || Intensity <= IntensityReflective)
+                {
+                    UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("Intensity is outof range. Something is wrong."));
+                }
                 retValue.Intensities.Add(IntensityScale * Intensity);
             }
         }

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RR2DLidarComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RR2DLidarComponent.cpp
@@ -330,9 +330,9 @@ FROSLaserScan URR2DLidarComponent::GetROS2Data()
                                                               FVector::DotProduct(HitSurfaceNormal, -RayDirection),
                                  IntensityNonReflective,
                                  IntensityReflective);
-                if (Intensity <= IntensityNonReflective || Intensity <= IntensityReflective)
+                if ((Intensity <= IntensityNonReflective) || (Intensity <= IntensityReflective))
                 {
-                    UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("Intensity is outof range. Something is wrong."));
+                    UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Intensity is outof range. Something is wrong."));
                 }
                 retValue.Intensities.Add(IntensityScale * Intensity);
             }

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RR3DLidarComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RR3DLidarComponent.cpp
@@ -333,9 +333,9 @@ FROSPointCloud2 URR3DLidarComponent::GetROS2Data()
                                                               FVector::DotProduct(HitSurfaceNormal, -RayDirection),
                                  IntensityNonReflective,
                                  IntensityReflective);
-                if (UnnormalizedIntensity <= IntensityNonReflective || UnnormalizedIntensity <= IntensityReflective)
+                if ((UnnormalizedIntensity <= IntensityNonReflective) || (UnnormalizedIntensity <= IntensityReflective))
                 {
-                    UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("Normalized intensity is outof range. Something is wrong."));
+                    UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Normalized intensity is outof range. Something is wrong."));
                 }
                 Intensity = IntensityScale * UnnormalizedIntensity;
             }

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RR3DLidarComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RR3DLidarComponent.cpp
@@ -333,8 +333,10 @@ FROSPointCloud2 URR3DLidarComponent::GetROS2Data()
                                                               FVector::DotProduct(HitSurfaceNormal, -RayDirection),
                                  IntensityNonReflective,
                                  IntensityReflective);
-                check(UnnormalizedIntensity >= IntensityNonReflective);
-                check(UnnormalizedIntensity <= IntensityReflective);
+                if (UnnormalizedIntensity <= IntensityNonReflective || UnnormalizedIntensity <= IntensityReflective)
+                {
+                    UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("Normalized intensity is outof range. Something is wrong."));
+                }
                 Intensity = IntensityScale * UnnormalizedIntensity;
             }
         }

--- a/Source/RapyutaSimulationPlugins/Private/Tools/OccupancyMapGenerator.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/OccupancyMapGenerator.cpp
@@ -62,7 +62,7 @@ void AOccupancyMapGenerator::BeginPlay()
     }
 
     // write to file
-    check(WriteToFile(NCellsX, NCellsY, Origin.X / 100.f, -(Center.Y + Extent.Y) / 100.f));
+    WriteToFile(NCellsX, NCellsY, Origin.X / 100.f, -(Center.Y + Extent.Y) / 100.f);
 }
 
 bool AOccupancyMapGenerator::WriteToFile(int width, int height, float originx, float originy)

--- a/Source/RapyutaSimulationPlugins/Private/Tools/RRROS2SkeletalMeshStatePublisher.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/RRROS2SkeletalMeshStatePublisher.cpp
@@ -35,7 +35,6 @@ void URRROS2SkeletalMeshStatePublisher::SetTargetRobot(ARobotVehicle* InRobot)
         SkeletalMeshComp = skeletalMeshComponents[0];
         const auto bonesNum = SkeletalMeshComp->GetBoneSpaceTransforms().Num();
         UE_LOG_WITH_INFO(LogRapyutaCore, Log, TEXT("[%s] has %d bones"), *SkeletalMeshComp->GetName(), bonesNum);
-        check(bonesNum > 0);
     }
     else
     {

--- a/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/SimulationState.cpp
@@ -63,7 +63,7 @@ void ASimulationState::RegisterSpawnableBPEntities(const TArray<FString>& InBPSp
 
 void ASimulationState::InitEntities()
 {
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
     TArray<AActor*> allActors;
     UGameplayStatics::GetAllActorsOfClass(GetWorld(), AActor::StaticClass(), allActors);
     UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("Found %d actors in the scene"), allActors.Num());

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -27,6 +27,8 @@
 
 #include "RRActorCommon.generated.h"
 
+#define RAPYUTA_SIM_VERBOSE (0)    // todo make this CVar
+
 #define RAPYUTA_SIM_DEBUG (0)
 #define RAPYUTA_SIM_VISUAL_DEBUG (0)
 
@@ -506,13 +508,13 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRActorSpawnInfo
     FString EntityModelName;
 
     /**
-     * @brief 
+     * @brief
      * Actually GetName() is also unique as noted by UE, but we just do not want to rely on it.
      * Instead, WE CREATE [UniqueName] TO MAKE OUR ID CONTROL MORE INDPENDENT of UE INTERNAL NAME HANDLING.
      * Reasons: Sometimes,
      * + UE provided Name Id is updated as Label is updated...
      * + In pending-kill state, GetName() goes to [None]
-     * 
+     *
      */
     UPROPERTY()
     FString UniqueName;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -30,10 +30,11 @@
 #define RAPYUTA_SIM_DEBUG (0)
 #define RAPYUTA_SIM_VISUAL_DEBUG (0)
 
+#define RAPYUTA_USE_SCENE_DIRECTOR (0)
+
 #define RAPYUTA_RUNTIME_MESH_ENTITY_USE_STATIC_MESH (1)
 #define RAPYUTA_RUNTIME_MESH_ENTITY_USE_PROCEDURAL_MESH (!RAPYUTA_RUNTIME_MESH_ENTITY_USE_STATIC_MESH)
 
-class ARRGameMode;
 class ARRGameState;
 class ARRMeshActor;
 class ARRMeshActor;
@@ -564,6 +565,7 @@ DECLARE_DELEGATE_TwoParams(FOnMeshActorFullyCreated, bool /* bCreationResult */,
 
 /**
  * @brief Scene instance's common object which houses Plugin-specific dynamic properties and implement objects-related API (Spawning, teleporting, etc.)
+ * If USE_SCENE_DIRECTOR is disabled, single ActorCommon is shared among all RRBaseActor.
  * @note Mostly responsible for holding handles to #URRSceneInstance  (Main environment, camera, etc.)
  */
 UCLASS(Config = RapyutaSimSettings)
@@ -616,14 +618,6 @@ public:
 
     static constexpr const TCHAR* MAP_ORIGIN_TAG = TEXT("map_origin");
     static constexpr const TCHAR* MAP_ROS_FRAME_ID = TEXT("map");
-
-    //! Game mode handle
-    UPROPERTY()
-    ARRGameMode* GameMode = nullptr;
-
-    //! Game state handle
-    UPROPERTY()
-    ARRGameState* GameState = nullptr;
 
     //! Each scene instance house a series of scene, in which operations are performed.
     UPROPERTY()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -565,7 +565,7 @@ DECLARE_DELEGATE_TwoParams(FOnMeshActorFullyCreated, bool /* bCreationResult */,
 
 /**
  * @brief Scene instance's common object which houses Plugin-specific dynamic properties and implement objects-related API (Spawning, teleporting, etc.)
- * If USE_SCENE_DIRECTOR is disabled, single ActorCommon is shared among all RRBaseActor.
+ * If USE_SCENE_DIRECTOR is disabled, there is only one single ActorCommon being shared among all RRBaseActor.
  * @note Mostly responsible for holding handles to #URRSceneInstance  (Main environment, camera, etc.)
  */
 UCLASS(Config = RapyutaSimSettings)

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
@@ -17,7 +17,7 @@
 
 #include "RRBaseActor.generated.h"
 
-class ARRROS2GameMode;
+class ARRGameMode;
 class ARRGameState;
 class URRGameSingleton;
 class ARRPlayerController;
@@ -74,19 +74,19 @@ public:
 
     static int8 SSceneInstanceId;
 
-    //! Used for SceneDirector
+    //! Pointer for convinience. Since this pointer can be nullptr, you need null check before using.
     UPROPERTY()
     ARRGameState* RRGameState = nullptr;
 
-    //! Used for Asset loading
+    //! Pointer for convinience. Since this pointer can be nullptr, you need null check before using.
     UPROPERTY()
     URRGameSingleton* RRGameSingleton = nullptr;
 
-    //! Pointer to GameMode for convinience.
+    //! Pointer for convinience. Since this pointer can be nullptr, you need null check before using.
     UPROPERTY()
-    ARRROS2GameMode* RRROS2GameMode = nullptr;
+    ARRGameMode* RRGameMode = nullptr;
 
-    //! Used for DataSynth app.
+    //! Pointer for convinience. Since this pointer can be nullptr, you need null check before using.
     UPROPERTY()
     ARRPlayerController* RRPlayerController = nullptr;
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
@@ -17,7 +17,7 @@
 
 #include "RRBaseActor.generated.h"
 
-class ARRGameMode;
+class ARRROS2GameMode;
 class ARRGameState;
 class URRGameSingleton;
 class ARRPlayerController;
@@ -76,11 +76,19 @@ public:
 
     //! Used for SceneDirector
     UPROPERTY()
-    ARRGameState* GameState = nullptr;
+    ARRGameState* RRGameState = nullptr;
 
     //! Used for Asset loading
     UPROPERTY()
-    URRGameSingleton* GameSingleton = nullptr;
+    URRGameSingleton* RRGameSingleton = nullptr;
+
+    //! Pointer to GameMode for convinience.
+    UPROPERTY()
+    ARRROS2GameMode* RRROS2GameMode = nullptr;
+
+    //! Used for DataSynth app.
+    UPROPERTY()
+    ARRPlayerController* RRPlayerController = nullptr;
 
     UPROPERTY()
     int8 SceneInstanceId = URRActorCommon::DEFAULT_SCENE_INSTANCE_ID;
@@ -134,7 +142,7 @@ public:
 protected:
     /**
      * @brief Set #GameMode #GameState #GameSingleton #PlayerController
-     * 
+     *
      */
     virtual void PreInitializeComponents() override;
     virtual void PrintSimConfig() const

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
@@ -73,20 +73,17 @@ public:
     TSharedPtr<FRRActorSpawnInfo> ActorInfo = nullptr;
 
     static int8 SSceneInstanceId;
-    UPROPERTY()
-    int8 SceneInstanceId = URRActorCommon::DEFAULT_SCENE_INSTANCE_ID;
 
-    UPROPERTY()
-    ARRGameMode* GameMode = nullptr;
-
+    //! Used for SceneDirector
     UPROPERTY()
     ARRGameState* GameState = nullptr;
 
+    //! Used for Asset loading
     UPROPERTY()
     URRGameSingleton* GameSingleton = nullptr;
 
     UPROPERTY()
-    ARRPlayerController* PlayerController = nullptr;
+    int8 SceneInstanceId = URRActorCommon::DEFAULT_SCENE_INSTANCE_ID;
 
     UPROPERTY()
     URRActorCommon* ActorCommon = nullptr;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameMode.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameMode.h
@@ -15,8 +15,6 @@
 
 #include "RRGameMode.generated.h"
 
-class URRGameInstance;
-
 /**
  * @brief todo
  * @todo add documentation
@@ -30,7 +28,7 @@ enum class ERRSimType : uint8
 };
 
 /**
- * @brief GameMode with specific setting, asset loading and #SceneDirector. Parent class, #ARRROS2GameMode, 
+ * @brief GameMode with specific setting, asset loading and #SceneDirector. Parent class, #ARRROS2GameMode,
  * You needs to use #RRGameSingleton for asset loading.
  * You needs to use #RRPlayerController and #RRGameState for SceneDirector.
  * @sa [GameMode and GameState](https://docs.unrealengine.com/5.1/en-US/game-mode-and-game-state-in-unreal-engine/)

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameMode.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameMode.h
@@ -30,8 +30,9 @@ enum class ERRSimType : uint8
 };
 
 /**
- * @brief GameMode with specific setting, asset loading. Parent class, #ARRROS2GameMode, 
- * handles ROS2 interface via #ClockPublisher and #ASimulationState.
+ * @brief GameMode with specific setting, asset loading and #SceneDirector. Parent class, #ARRROS2GameMode, 
+ * You needs to use #RRGameSingleton for asset loading.
+ * You needs to use #RRPlayerController and #RRGameState for SceneDirector.
  * @sa [GameMode and GameState](https://docs.unrealengine.com/5.1/en-US/game-mode-and-game-state-in-unreal-engine/)
  */
 UCLASS(Config = RapyutaSimSettings)
@@ -90,8 +91,6 @@ public:
         return simTypeName;
     }
 
-    UPROPERTY() URRGameInstance* GameInstance = nullptr;
-
     virtual void PreInitializeComponents() override;
     virtual void InitGameState() override;
 
@@ -117,8 +116,11 @@ public:
      *  asynchronous resource loading, could only run after this [ARRGameState::BeginPlay()] ends!
      */
     virtual void StartSim();
+
     UPROPERTY(config)
     bool bBenchmark = true;
+
+    void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 private:
     FTimerHandle OwnTimerHandle;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameState.h
@@ -19,7 +19,6 @@
 
 class ARRGameMode;
 class URRGameInstance;
-class ARRPlayerController;
 class ARRMeshActor;
 
 /**
@@ -50,9 +49,6 @@ public:
 
     UPROPERTY()
     ARRGameMode* GameMode = nullptr;
-
-    UPROPERTY()
-    URRGameInstance* GameInstance = nullptr;
 
     UPROPERTY(config)
     float SCENE_INSTANCES_DISTANCE_INTERVAL = 5000.f;

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRPlayerController.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRPlayerController.h
@@ -21,7 +21,7 @@ class ARRActorCommon;
 class ARRCamera;
 
 /**
- * @brief Player controller with #ARRGameMode, #ARRGameState, #URRGameInstance and #URRActorCommon
+ * @brief Player controller designed to be used with SceneDirector
  *
  */
 UCLASS()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRUObjectUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRUObjectUtils.h
@@ -530,7 +530,7 @@ public:
             newSimActor->SetActorLabel(InActorSpawnInfo.UniqueName);
 #endif
 
-#if RAPYUTA_SIM_DEBUG
+#if RAPYUTA_SIM_VERBOSE
             UE_LOG_WITH_INFO(LogTemp,
                              Warning,
                              TEXT("[%s:%d] SIM ACTOR SPAWNED: [%s] => [%s]\nat %s -> %s"),


### PR DESCRIPTION
- update dependency and check. 
- Make ROS2GameMode and ARRBaseRobot available without RRGameSingleton and etc
- Rem use of `ARRGameInstance` which is just printing log
- Decoupling with `ARRPlayerController`, which is only used with SceneDirector
- update log level
- Make RAPYUTA_USE_SCENE_DIRECTOR optional
- Add RAPYUTA_SIM_VERBOSE