### PR TITLE
RRBaseRobot AngularVel in Degree

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRNetworkPlayerController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRNetworkPlayerController.cpp
@@ -215,7 +215,7 @@ void ARRNetworkPlayerController::ServerSetLinearVel_Implementation(ARRBaseRobot*
 void ARRNetworkPlayerController::ServerSetAngularVel_Implementation(ARRBaseRobot* InServerRobot,
                                                                     float InClientTimeStamp,
                                                                     const FRotator& InClientRobotRotation,
-                                                                    const FRotator& InAngularVel)
+                                                                    const FVector& InAngularVel)
 {
 #if RAPYUTA_SIM_DEBUG
     UE_LOG_WITH_INFO_NAMED(
@@ -225,7 +225,8 @@ void ARRNetworkPlayerController::ServerSetAngularVel_Implementation(ARRBaseRobot
     if (robot)
     {
         float serverCurrentTime = UGameplayStatics::GetRealTimeSeconds(GetWorld());
-        robot->SetActorRotation(InClientRobotRotation + InAngularVel * (serverCurrentTime - InClientTimeStamp));
+        robot->SetActorRotation(InClientRobotRotation +
+                                FRotator::MakeFromEuler(InAngularVel) * (serverCurrentTime - InClientTimeStamp));
         //NOTE: Don't use ARRBaseRobot::SetAngularVel() here, which is only for client
         robot->TargetAngularVel = InAngularVel;
     }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRNetworkPlayerController.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRNetworkPlayerController.cpp
@@ -17,7 +17,6 @@
 #include "Core/RRCoreUtils.h"
 #include "Core/RRUObjectUtils.h"
 #include "Robots/RRBaseRobot.h"
-#include "Robots/RRBaseRobot.h"
 #include "Robots/RRRobotROS2Interface.h"
 #include "Tools/RRROS2SimulationStateClient.h"
 #include "Tools/SimulationState.h"
@@ -216,7 +215,7 @@ void ARRNetworkPlayerController::ServerSetLinearVel_Implementation(ARRBaseRobot*
 void ARRNetworkPlayerController::ServerSetAngularVel_Implementation(ARRBaseRobot* InServerRobot,
                                                                     float InClientTimeStamp,
                                                                     const FRotator& InClientRobotRotation,
-                                                                    const FVector& InAngularVel)
+                                                                    const FRotator& InAngularVel)
 {
 #if RAPYUTA_SIM_DEBUG
     UE_LOG_WITH_INFO_NAMED(
@@ -226,7 +225,7 @@ void ARRNetworkPlayerController::ServerSetAngularVel_Implementation(ARRBaseRobot
     if (robot)
     {
         float serverCurrentTime = UGameplayStatics::GetRealTimeSeconds(GetWorld());
-        robot->SetActorRotation(InClientRobotRotation + InAngularVel.Rotation() * (serverCurrentTime - InClientTimeStamp));
+        robot->SetActorRotation(InClientRobotRotation + InAngularVel * (serverCurrentTime - InClientTimeStamp));
         //NOTE: Don't use ARRBaseRobot::SetAngularVel() here, which is only for client
         robot->TargetAngularVel = InAngularVel;
     }

--- a/Source/RapyutaSimulationPlugins/Private/Drives/DifferentialDriveComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/DifferentialDriveComponent.cpp
@@ -56,7 +56,7 @@ void UDifferentialDriveComponent::UpdateMovement(float DeltaTime)
 {
     if (IsValid(WheelLeft) && IsValid(WheelRight))
     {
-        const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Yaw);
+        const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Z);
         float velL = Velocity.X + angularVelRad * WheelSeparationHalf;
         float velR = Velocity.X - angularVelRad * WheelSeparationHalf;
 
@@ -99,7 +99,7 @@ void UDifferentialDriveComponent::UpdateOdom(float DeltaTime)
     // in the kinematics case, (dx,dy,dtheta) can be simplified considerably
     // but as this is not a performance bottleneck, for the moment we leave the full general formulation,
     // at least until the odom for the physics version of the agent is implemented, so that we have a reference
-    const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Yaw);
+    const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Z);
     float vl = Velocity.X + angularVelRad * WheelSeparationHalf;
     float vr = Velocity.X - angularVelRad * WheelSeparationHalf;
 

--- a/Source/RapyutaSimulationPlugins/Private/Drives/DifferentialDriveComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/DifferentialDriveComponent.cpp
@@ -81,9 +81,9 @@ void UDifferentialDriveComponent::UpdateOdom(float DeltaTime)
     if (!OdomComponent->bIsOdomInitialized)
     {
         OdomComponent->InitOdom();
-        PoseEncoderX = 0;
-        PoseEncoderY = 0;
-        PoseEncoderTheta = 0;
+        PoseEncoderX = 0.f;
+        PoseEncoderY = 0.f;
+        PoseEncoderThetaRad = 0.f;
     }
 
     FROSOdom odomData = OdomComponent->OdomData;
@@ -112,13 +112,13 @@ void UDifferentialDriveComponent::UpdateOdom(float DeltaTime)
 
     float sdiff = sr - sl;
 
-    float dx = ssum * .5f * cos(PoseEncoderTheta + sdiff / (4.f * WheelSeparationHalf));
-    float dy = ssum * .5f * sin(PoseEncoderTheta + sdiff / (4.f * WheelSeparationHalf));
+    float dx = ssum * .5f * cos(PoseEncoderThetaRad + sdiff / (4.f * WheelSeparationHalf));
+    float dy = ssum * .5f * sin(PoseEncoderThetaRad + sdiff / (4.f * WheelSeparationHalf));
     float dtheta = -sdiff / (2.f * WheelSeparationHalf);
 
     PoseEncoderX += dx;
     PoseEncoderY += dy;
-    PoseEncoderTheta += dtheta;
+    PoseEncoderThetaRad += dtheta;
 
     float w = dtheta / DeltaTime;
     float v = sqrt(dx * dx + dy * dy) / DeltaTime;
@@ -127,7 +127,7 @@ void UDifferentialDriveComponent::UpdateOdom(float DeltaTime)
     odomData.Pose.Pose.Position.Y = PoseEncoderY;
     odomData.Pose.Pose.Position.Z = 0;
 
-    odomData.Pose.Pose.Orientation = FQuat(FVector::ZAxisVector, PoseEncoderTheta);
+    odomData.Pose.Pose.Orientation = FQuat(FVector::ZAxisVector, PoseEncoderThetaRad);
 
     odomData.Twist.Twist.Angular.Z = w;
     odomData.Twist.Twist.Linear.X = v;
@@ -149,14 +149,30 @@ void UDifferentialDriveComponent::UpdateOdom(float DeltaTime)
 
     OdomComponent->OdomData = odomData;
 
-    // UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("Input:"));
-    // UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("\tVel: %s, %s"), *Velocity.ToString(), *AngularVelocity.ToString());
-    // UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("Odometry:"));
-    // UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("\tOdom Positon:\t\t\t\t%f %f from %f %f (%f)"), PoseEncoderX, PoseEncoderY, dx, dy,
-    // Velocity.X); UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("\tOdom Orientation:\t\t\t%s (%f)"), *OdomData.Pose.Pose.Orientation.ToString(),
-    // PoseEncoderTheta); UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("\tOdom TwistLin:\t\t\t\t%s - %f"), *OdomData.Twist.Twist.Linear.ToString(),
-    // OdomData.Twist.Twist.Linear.Size()); UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("\tOdom TwistAng:\t\t\t\t%s"),
-    // *OdomData.Twist.Twist.Angular.ToString());
+#if RAPYUTA_SIM_VERBOSE
+    UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Input:"));
+    UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("\tVel: %s, %s"), *Velocity.ToString(), *AngularVelocity.ToString());
+    UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Odometry:"));
+    UE_LOG_WITH_INFO(LogRapyutaCore,
+                     Warning,
+                     TEXT("\tOdom Positon:\t\t\t\t%f %f from %f %f (%f)"),
+                     PoseEncoderX,
+                     PoseEncoderY,
+                     dx,
+                     dy,
+                     Velocity.X);
+    UE_LOG_WITH_INFO(LogRapyutaCore,
+                     Warning,
+                     TEXT("\tOdom Orientation:\t\t\t%s (%f)"),
+                     *odomData.Pose.Pose.Orientation.ToString(),
+                     PoseEncoderThetaRad);
+    UE_LOG_WITH_INFO(LogTemp,
+                     Warning,
+                     TEXT("\tOdom TwistLin:\t\t\t\t%s - %f"),
+                     *odomData.Twist.Twist.Linear.ToString(),
+                     odomData.Twist.Twist.Linear.Size());
+    UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("\tOdom TwistAng:\t\t\t\t%s"), *odomData.Twist.Twist.Angular.ToString());
+#endif
 }
 
 void UDifferentialDriveComponent::Initialize()

--- a/Source/RapyutaSimulationPlugins/Private/Drives/DifferentialDriveComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/DifferentialDriveComponent.cpp
@@ -123,13 +123,11 @@ void UDifferentialDriveComponent::UpdateOdom(float DeltaTime)
     float w = dtheta / DeltaTime;
     float v = sqrt(dx * dx + dy * dy) / DeltaTime;
 
-    FQuat qt(FVector::ZAxisVector, PoseEncoderTheta);
-
     odomData.Pose.Pose.Position.X = PoseEncoderX;
     odomData.Pose.Pose.Position.Y = PoseEncoderY;
     odomData.Pose.Pose.Position.Z = 0;
 
-    odomData.Pose.Pose.Orientation = qt;
+    odomData.Pose.Pose.Orientation = FQuat(FVector::ZAxisVector, PoseEncoderTheta);
 
     odomData.Twist.Twist.Angular.Z = w;
     odomData.Twist.Twist.Linear.X = v;

--- a/Source/RapyutaSimulationPlugins/Private/Drives/DifferentialDriveComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/DifferentialDriveComponent.cpp
@@ -56,8 +56,9 @@ void UDifferentialDriveComponent::UpdateMovement(float DeltaTime)
 {
     if (IsValid(WheelLeft) && IsValid(WheelRight))
     {
-        float velL = Velocity.X + AngularVelocity.Z * WheelSeparationHalf;
-        float velR = Velocity.X - AngularVelocity.Z * WheelSeparationHalf;
+        const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Yaw);
+        float velL = Velocity.X + angularVelRad * WheelSeparationHalf;
+        float velR = Velocity.X - angularVelRad * WheelSeparationHalf;
 
         WheelLeft->SetAngularVelocityTarget(FVector(-velL / WheelPerimeter, 0, 0));
         WheelRight->SetAngularVelocityTarget(FVector(-velR / WheelPerimeter, 0, 0));
@@ -98,8 +99,9 @@ void UDifferentialDriveComponent::UpdateOdom(float DeltaTime)
     // in the kinematics case, (dx,dy,dtheta) can be simplified considerably
     // but as this is not a performance bottleneck, for the moment we leave the full general formulation,
     // at least until the odom for the physics version of the agent is implemented, so that we have a reference
-    float vl = Velocity.X + AngularVelocity.Z * WheelSeparationHalf;
-    float vr = Velocity.X - AngularVelocity.Z * WheelSeparationHalf;
+    const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Yaw);
+    float vl = Velocity.X + angularVelRad * WheelSeparationHalf;
+    float vr = Velocity.X - angularVelRad * WheelSeparationHalf;
 
     // noise added as a component of vl, vr
     // Gazebo links this Book here: Sigwart 2011 Autonomous Mobile Robots page:337
@@ -121,8 +123,7 @@ void UDifferentialDriveComponent::UpdateOdom(float DeltaTime)
     float w = dtheta / DeltaTime;
     float v = sqrt(dx * dx + dy * dy) / DeltaTime;
 
-    // FRotator is in degrees, while PoseEncoderTheta is in Radians
-    FQuat qt(FRotator(0, FMath::RadiansToDegrees(PoseEncoderTheta), 0));
+    FQuat qt(FVector::ZAxisVector, PoseEncoderTheta);
 
     odomData.Pose.Pose.Position.X = PoseEncoderX;
     odomData.Pose.Pose.Position.Y = PoseEncoderY;

--- a/Source/RapyutaSimulationPlugins/Private/Drives/RRFloatingMovementComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/RRFloatingMovementComponent.cpp
@@ -60,7 +60,7 @@ void URRFloatingMovementComponent::TickComponent(float InDeltaTime,
     {
         URRMathUtils::ClampVectorToMaxMagnitude(Velocity, MaxSpeed, b2DMovement);
     }
-    URRMathUtils::ClampRotatorToMaxAngles(AngularVelocity, FRotator(MaxAngularSpeed));
+    URRMathUtils::ClampVectorToMaxMagnitude(AngularVelocity, MaxAngularSpeed, false);
 
     if (false == b2DMovement)
     {
@@ -70,7 +70,7 @@ void URRFloatingMovementComponent::TickComponent(float InDeltaTime,
 
     // Move [UpdatedComponent], updating [bPositionCorrected] here-in
     FVector deltaLoc = Velocity * InDeltaTime;
-    FRotator deltaRot = AngularVelocity * InDeltaTime;
+    FRotator deltaRot = FRotator::MakeFromEuler(AngularVelocity) * InDeltaTime;
     if ((!deltaLoc.IsNearlyZero(1e-6f)) || (!deltaRot.IsNearlyZero(1e-3f)))
     {
         // Save prevLocation
@@ -90,9 +90,9 @@ void URRFloatingMovementComponent::TickComponent(float InDeltaTime,
             {
                 UE_LOG_WITH_INFO(LogRapyutaCore,
                                  Warning,
-                                 TEXT("deltaRot.Yaw: %f, AngularVelocity.Yaw: %f[deg], MaxAngularSpeed: %f[deg], inDeltaTime: %f"),
+                                 TEXT("deltaRot.Yaw: %f, AngularVelocity.Z: %f[deg], MaxAngularSpeed: %f[deg], inDeltaTime: %f"),
                                  deltaRot.Yaw,
-                                 AngularVelocity.Yaw,
+                                 AngularVelocity.Z,
                                  MaxAngularSpeed,
                                  InDeltaTime);
             }
@@ -266,6 +266,6 @@ bool URRFloatingMovementComponent::ResolvePenetrationImpl(const FVector& InPropo
 
 void URRFloatingMovementComponent::StopMovementImmediately()
 {
-    AngularVelocity = FRotator::ZeroRotator;
+    AngularVelocity = FVector::ZeroVector;
     Super::StopMovementImmediately();
 }

--- a/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
@@ -97,8 +97,9 @@ void URobotVehicleMovementComponent::UpdateMovement(float InDeltaTime)
 
     const FQuat oldRotation = UpdatedComponent->GetComponentQuat();
 
-    FVector position = UpdatedComponent->ComponentVelocity * InDeltaTime;
-    FQuat deltaRotation(FVector::ZAxisVector, InversionFactor * AngularVelocity.Z * InDeltaTime);
+    const FVector position = UpdatedComponent->ComponentVelocity * InDeltaTime;
+    const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Yaw);
+    const FQuat deltaRotation(FVector::ZAxisVector, InversionFactor * angularVelRad * InDeltaTime);
 
     DesiredRotation = oldRotation * deltaRotation;
     DesiredMovement = (oldRotation * position);

--- a/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Drives/RobotVehicleMovementComponent.cpp
@@ -98,7 +98,7 @@ void URobotVehicleMovementComponent::UpdateMovement(float InDeltaTime)
     const FQuat oldRotation = UpdatedComponent->GetComponentQuat();
 
     const FVector position = UpdatedComponent->ComponentVelocity * InDeltaTime;
-    const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Yaw);
+    const float angularVelRad = FMath::DegreesToRadians(AngularVelocity.Z);
     const FQuat deltaRotation(FVector::ZAxisVector, InversionFactor * angularVelRad * InDeltaTime);
 
     DesiredRotation = oldRotation * deltaRotation;

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -400,7 +400,7 @@ void ARRBaseRobot::StopMovement()
         moveComp->StopMovementImmediately();
     }
     SetLinearVel(FVector::ZeroVector);
-    SetAngularVel(FRotator::ZeroRotator);
+    SetAngularVel(FVector::ZeroVector);
 }
 
 void ARRBaseRobot::SetLinearVel(const FVector& InLinearVel)
@@ -409,7 +409,7 @@ void ARRBaseRobot::SetLinearVel(const FVector& InLinearVel)
     SetLocalLinearVel(InLinearVel);
 }
 
-void ARRBaseRobot::SetAngularVel(const FRotator& InAngularVel)
+void ARRBaseRobot::SetAngularVel(const FVector& InAngularVel)
 {
     SyncServerAngularMovement(GetWorld()->GetGameState()->GetServerWorldTimeSeconds(), GetActorRotation(), InAngularVel);
     SetLocalAngularVel(InAngularVel);
@@ -435,14 +435,14 @@ void ARRBaseRobot::SyncServerLinearMovement(float InClientTimeStamp,
 
 void ARRBaseRobot::SyncServerAngularMovement(float InClientTimeStamp,
                                              const FRotator& InClientRobotRotation,
-                                             const FRotator& InAngularVel)
+                                             const FVector& InAngularVel)
 {
     // todo: following block is used for RPC in server, which will be used if RPC from non player can be supported.
     // if (RobotVehicleMoveComponent)
     // {
     //     // GetPlayerController<APlayerController>(0, InContextObject)
     //     float serverCurrentTime = UGameplayStatics::GetRealTimeSeconds(GetWorld());
-    //     SetActorRotation(InClientRobotRotation + InAngularVel * (serverCurrentTime - InClientTimeStamp));
+    //     SetActorRotation(InClientRobotRotation + FRotator::MakeFromEuler(InAngularVel) * (serverCurrentTime - InClientTimeStamp));
     //     RobotVehicleMoveComponent->AngularVelocity = InAngularVel;
     // }
 
@@ -466,7 +466,7 @@ void ARRBaseRobot::SetLocalLinearVel(const FVector& InLinearVel)
 #endif
 }
 
-void ARRBaseRobot::SetLocalAngularVel(const FRotator& InAngularVel)
+void ARRBaseRobot::SetLocalAngularVel(const FVector& InAngularVel)
 {
     TargetAngularVel = InAngularVel;
 #if RAPYUTA_SIM_DEBUG

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -400,7 +400,7 @@ void ARRBaseRobot::StopMovement()
         moveComp->StopMovementImmediately();
     }
     SetLinearVel(FVector::ZeroVector);
-    SetAngularVel(FVector::ZeroVector);
+    SetAngularVel(FRotator::ZeroRotator);
 }
 
 void ARRBaseRobot::SetLinearVel(const FVector& InLinearVel)
@@ -409,7 +409,7 @@ void ARRBaseRobot::SetLinearVel(const FVector& InLinearVel)
     SetLocalLinearVel(InLinearVel);
 }
 
-void ARRBaseRobot::SetAngularVel(const FVector& InAngularVel)
+void ARRBaseRobot::SetAngularVel(const FRotator& InAngularVel)
 {
     SyncServerAngularMovement(GetWorld()->GetGameState()->GetServerWorldTimeSeconds(), GetActorRotation(), InAngularVel);
     SetLocalAngularVel(InAngularVel);
@@ -435,14 +435,14 @@ void ARRBaseRobot::SyncServerLinearMovement(float InClientTimeStamp,
 
 void ARRBaseRobot::SyncServerAngularMovement(float InClientTimeStamp,
                                              const FRotator& InClientRobotRotation,
-                                             const FVector& InAngularVel)
+                                             const FRotator& InAngularVel)
 {
     // todo: following block is used for RPC in server, which will be used if RPC from non player can be supported.
     // if (RobotVehicleMoveComponent)
     // {
     //     // GetPlayerController<APlayerController>(0, InContextObject)
     //     float serverCurrentTime = UGameplayStatics::GetRealTimeSeconds(GetWorld());
-    //     SetActorRotation(InClientRobotRotation + InAngularVel.Rotation() * (serverCurrentTime - InClientTimeStamp));
+    //     SetActorRotation(InClientRobotRotation + InAngularVel * (serverCurrentTime - InClientTimeStamp));
     //     RobotVehicleMoveComponent->AngularVelocity = InAngularVel;
     // }
 
@@ -466,7 +466,7 @@ void ARRBaseRobot::SetLocalLinearVel(const FVector& InLinearVel)
 #endif
 }
 
-void ARRBaseRobot::SetLocalAngularVel(const FVector& InAngularVel)
+void ARRBaseRobot::SetLocalAngularVel(const FRotator& InAngularVel)
 {
     TargetAngularVel = InAngularVel;
 #if RAPYUTA_SIM_DEBUG

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
@@ -298,7 +298,7 @@ void URRRobotROS2Interface::MovementCallback(const UROS2GenericMsg* Msg)
         FROSTwist twist;
         twistMsg->GetMsg(twist);
         const FVector linear(URRConversionUtils::VectorROSToUE(twist.Linear));
-        const FVector angular(FMath::RadiansToDegrees(URRConversionUtils::RotationROSToUE(twist.Angular)));
+        const FRotator angular(URRConversionUtils::RotationROSToUE(twist.Angular));
 
         // (Note) In this callback, which could be invoked from a ROS working thread,
         // thus any direct referencing to its member in this GameThread lambda needs to be verified.

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp
@@ -297,8 +297,8 @@ void URRRobotROS2Interface::MovementCallback(const UROS2GenericMsg* Msg)
         // probably should not stay in msg though
         FROSTwist twist;
         twistMsg->GetMsg(twist);
-        const FVector linear(URRConversionUtils::VectorROSToUE(twist.Linear));
-        const FRotator angular(URRConversionUtils::RotationROSToUE(twist.Angular));
+        const FVector linear = URRConversionUtils::VectorROSToUE(twist.Linear);
+        const FVector angular = URRConversionUtils::RotationROSToUEVector(twist.Angular, true);
 
         // (Note) In this callback, which could be invoked from a ROS working thread,
         // thus any direct referencing to its member in this GameThread lambda needs to be verified.

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RRBaseOdomComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RRBaseOdomComponent.cpp
@@ -124,8 +124,7 @@ void URRBaseOdomComponent::UpdateOdom(float InDeltaTime)
     OdomData.Pose.Pose.Orientation = rot;
 
     OdomData.Twist.Twist.Linear = OdomData.Pose.Pose.Orientation.UnrotateVector(pos - previousEstimatedPos) / InDeltaTime;
-    OdomData.Twist.Twist.Angular =
-        FMath::DegreesToRadians((rot * previousEstimatedRot.Inverse()).GetNormalized().Euler()) / InDeltaTime;
+    OdomData.Twist.Twist.Angular = (rot * previousEstimatedRot.Inverse()).GetNormalized().Euler() / InDeltaTime;
 
     OdomData.Pose.Pose.Orientation *= RootOffset.GetRotation();
 }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
@@ -152,15 +152,29 @@ public:
         OutputZ = InputZ * 100.f;
     }
 
+    /**
+     * @brief Convert ROS Rotation Euler (rad) to UE Vector retaining unit as [rad]
+     * @param Input
+     * @return FVector
+     */
     UFUNCTION(BlueprintCallable, Category = "Conversion")
-    static FVector RotationROSToUE(const FVector& Input)
+    static FVector RotationROSToUEVector(const FVector& Input)
     {
-        FVector Output = Input;
+        FVector output = Input;
+        output.Y = -output.Y;
+        output.Z = -output.Z;
+        return output;
+    }
 
-        Output.Y = -Output.Y;
-        Output.Z = -Output.Z;
-
-        return Output;
+    /**
+     * @brief Convert ROS Rotation (rad) to UE Rotator (deg)
+     * @param InROSPose
+     * @return FRotator
+     */
+    UFUNCTION(BlueprintCallable, Category = "Conversion")
+    static FRotator RotationROSToUE(const FVector& Input)
+    {
+        return FRotator::MakeFromEuler(FMath::RadiansToDegrees(RotationROSToUEVector(Input)));
     }
 
     UFUNCTION(BlueprintCallable, Category = "Conversion")
@@ -201,7 +215,7 @@ public:
         Output.Pose.Pose.Orientation = QuatROSToUE(Output.Pose.Pose.Orientation);
 
         Output.Twist.Twist.Linear = VectorROSToUE(Output.Twist.Twist.Linear);
-        Output.Twist.Twist.Angular = RotationROSToUE(Output.Twist.Twist.Angular);
+        Output.Twist.Twist.Angular = RotationROSToUEVector(Output.Twist.Twist.Angular);
 
         return Output;
     }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
@@ -72,6 +72,12 @@ public:
         OutputZ = InputZ * 0.01f;
     }
 
+    /**
+     * @brief Convert UE Rotation to ROS Vector with optional Deg->Rad conversion
+     * @param Input
+     * @param bDegToRad
+     * @return FVector
+     */
     UFUNCTION(BlueprintCallable, Category = "Conversion")
     static FVector RotationUEToROS(const FVector& Input, const bool bDegToRad)
     {
@@ -152,8 +158,9 @@ public:
     }
 
     /**
-     * @brief Convert ROS Rotation Euler (rad) to UE Vector retaining unit as [rad]
+     * @brief Convert ROS Rotation Euler (rad) to UE Vector with optional Rad->Deg conversion
      * @param Input
+     * @param bRadToDeg
      * @return FVector
      */
     UFUNCTION(BlueprintCallable, Category = "Conversion")

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
@@ -79,7 +79,7 @@ public:
      * @return FVector
      */
     UFUNCTION(BlueprintCallable, Category = "Conversion")
-    static FVector RotationUEToROS(const FVector& Input, const bool bDegToRad)
+    static FVector RotationUEVectorToROS(const FVector& Input, const bool bDegToRad = true)
     {
         FVector output = Input;
         output.Y = -output.Y;
@@ -119,13 +119,14 @@ public:
         Output.Pose.Pose.Orientation = QuatUEToROS(Output.Pose.Pose.Orientation);
 
         Output.Twist.Twist.Linear = VectorUEToROS(Output.Twist.Twist.Linear);
-        Output.Twist.Twist.Angular = RotationUEToROS(Output.Twist.Twist.Angular, false);
+        Output.Twist.Twist.Angular = RotationUEVectorToROS(Output.Twist.Twist.Angular);
 
         return Output;
     }
 
     // ROS to UE conversion
     // m -> cm
+    // rad -> degree
     // Right handed -> Left handed
 
     UFUNCTION(BlueprintCallable, Category = "Conversion")
@@ -160,11 +161,11 @@ public:
     /**
      * @brief Convert ROS Rotation Euler (rad) to UE Vector with optional Rad->Deg conversion
      * @param Input
-     * @param bRadToDeg
+     * @param bRadToDeg convert radian to degree or not
      * @return FVector
      */
     UFUNCTION(BlueprintCallable, Category = "Conversion")
-    static FVector RotationROSToUEVector(const FVector& Input, const bool bRadToDeg)
+    static FVector RotationROSToUEVector(const FVector& Input, const bool bRadToDeg = true)
     {
         FVector output = Input;
         output.Y = -output.Y;
@@ -211,7 +212,7 @@ public:
         Output.Pose.Pose.Orientation = QuatROSToUE(Output.Pose.Pose.Orientation);
 
         Output.Twist.Twist.Linear = VectorROSToUE(Output.Twist.Twist.Linear);
-        Output.Twist.Twist.Angular = RotationROSToUEVector(Output.Twist.Twist.Angular, false);
+        Output.Twist.Twist.Angular = RotationROSToUEVector(Output.Twist.Twist.Angular);
 
         return Output;
     }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
@@ -73,14 +73,13 @@ public:
     }
 
     UFUNCTION(BlueprintCallable, Category = "Conversion")
-    static FVector RotationUEToROS(const FVector& Input)
+    static FVector RotationUEToROS(const FVector& Input, const bool bDegToRad)
     {
-        FVector Output = Input;
+        FVector output = Input;
+        output.Y = -output.Y;
+        output.Z = -output.Z;
 
-        Output.Y = -Output.Y;
-        Output.Z = -Output.Z;
-
-        return Output;
+        return bDegToRad ? FMath::DegreesToRadians(output) : output;
     }
 
     UFUNCTION(BlueprintCallable, Category = "Conversion")
@@ -114,7 +113,7 @@ public:
         Output.Pose.Pose.Orientation = QuatUEToROS(Output.Pose.Pose.Orientation);
 
         Output.Twist.Twist.Linear = VectorUEToROS(Output.Twist.Twist.Linear);
-        Output.Twist.Twist.Angular = RotationUEToROS(Output.Twist.Twist.Angular);
+        Output.Twist.Twist.Angular = RotationUEToROS(Output.Twist.Twist.Angular, false);
 
         return Output;
     }
@@ -158,23 +157,13 @@ public:
      * @return FVector
      */
     UFUNCTION(BlueprintCallable, Category = "Conversion")
-    static FVector RotationROSToUEVector(const FVector& Input)
+    static FVector RotationROSToUEVector(const FVector& Input, const bool bRadToDeg)
     {
         FVector output = Input;
         output.Y = -output.Y;
         output.Z = -output.Z;
-        return output;
-    }
 
-    /**
-     * @brief Convert ROS Rotation (rad) to UE Rotator (deg)
-     * @param InROSPose
-     * @return FRotator
-     */
-    UFUNCTION(BlueprintCallable, Category = "Conversion")
-    static FRotator RotationROSToUE(const FVector& Input)
-    {
-        return FRotator::MakeFromEuler(FMath::RadiansToDegrees(RotationROSToUEVector(Input)));
+        return bRadToDeg ? FMath::RadiansToDegrees(output) : output;
     }
 
     UFUNCTION(BlueprintCallable, Category = "Conversion")
@@ -215,7 +204,7 @@ public:
         Output.Pose.Pose.Orientation = QuatROSToUE(Output.Pose.Pose.Orientation);
 
         Output.Twist.Twist.Linear = VectorROSToUE(Output.Twist.Twist.Linear);
-        Output.Twist.Twist.Angular = RotationROSToUEVector(Output.Twist.Twist.Angular);
+        Output.Twist.Twist.Angular = RotationROSToUEVector(Output.Twist.Twist.Angular, false);
 
         return Output;
     }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRNetworkPlayerController.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRNetworkPlayerController.h
@@ -163,11 +163,11 @@ public:
     virtual void ServerSetAngularVel(ARRBaseRobot* InServerRobot,
                                      float InClientTimeStamp,
                                      const FRotator& InClientRobotRotation,
-                                     const FRotator& InAngularVel);
+                                     const FVector& InAngularVel);
 
 protected:
     /**
-     * @brief 
+     * @brief
      * Standalone game mode will call this method to call #ClientInitSimStateClientROS2lient.
      * Client server game mode will start timer to sync time with server.
      */

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRNetworkPlayerController.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRNetworkPlayerController.h
@@ -163,7 +163,7 @@ public:
     virtual void ServerSetAngularVel(ARRBaseRobot* InServerRobot,
                                      float InClientTimeStamp,
                                      const FRotator& InClientRobotRotation,
-                                     const FVector& InAngularVel);
+                                     const FRotator& InAngularVel);
 
 protected:
     /**

--- a/Source/RapyutaSimulationPlugins/Public/Drives/DifferentialDriveComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/DifferentialDriveComponent.h
@@ -109,10 +109,10 @@ protected:
     UPROPERTY()
     float WheelPerimeter = 6.28f;
 
-    //! [rad]
+    //! [cm]
     UPROPERTY()
     float PoseEncoderX = 0.f;
-    //! [rad]
+    //! [cm]
     UPROPERTY()
     float PoseEncoderY = 0.f;
     //! [rad]

--- a/Source/RapyutaSimulationPlugins/Public/Drives/DifferentialDriveComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/DifferentialDriveComponent.h
@@ -117,5 +117,5 @@ protected:
     float PoseEncoderY = 0.f;
     //! [rad]
     UPROPERTY()
-    float PoseEncoderTheta = 0.f;
+    float PoseEncoderThetaRad = 0.f;
 };

--- a/Source/RapyutaSimulationPlugins/Public/Drives/DifferentialDriveComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/DifferentialDriveComponent.h
@@ -92,10 +92,11 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     UPhysicsConstraintComponent* WheelRight = nullptr;
 
+    //! [cm]
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     float WheelRadius = 1.f;
 
-    //! @todo get data from links
+    //! [cm] @todo get data from links
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     float WheelSeparationHalf = 1.f;
 
@@ -104,13 +105,17 @@ public:
     float MaxForce = 1000.f;
 
 protected:
+    //! [cm]
     UPROPERTY()
     float WheelPerimeter = 6.28f;
 
+    //! [rad]
     UPROPERTY()
     float PoseEncoderX = 0.f;
+    //! [rad]
     UPROPERTY()
     float PoseEncoderY = 0.f;
+    //! [rad]
     UPROPERTY()
     float PoseEncoderTheta = 0.f;
 };

--- a/Source/RapyutaSimulationPlugins/Public/Drives/RRFloatingMovementComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/RRFloatingMovementComponent.h
@@ -35,9 +35,9 @@ public:
         return b2DMovement;
     }
 
-    //! [deg/s] Current AngularVelocity of #UpdatedComponent
+    //! [deg/s] Current AngularVelocity of #UpdatedComponent [X:Roll - Y:Pitch - Z: Yaw]
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FRotator AngularVelocity = FRotator::ZeroRotator;
+    FVector AngularVelocity = FVector::ZeroVector;
 
     //! Maximum angular speed magnitude allowed for #UpdatedComponent
     //! [deg/s]

--- a/Source/RapyutaSimulationPlugins/Public/Drives/RobotVehicleMovementComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/RobotVehicleMovementComponent.h
@@ -81,7 +81,7 @@ public:
 
     //! [deg/s] AngularVelocity control input for [UpdatedComponent]
     UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = Velocity)
-    FRotator AngularVelocity = FRotator::ZeroRotator;
+    FVector AngularVelocity = FVector::ZeroVector;
 
     //! Desired position calculated from deltatime and UpdatedComponent::ComponentVelocity
     //! @sa

--- a/Source/RapyutaSimulationPlugins/Public/Drives/RobotVehicleMovementComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Drives/RobotVehicleMovementComponent.h
@@ -81,7 +81,7 @@ public:
 
     //! [deg/s] AngularVelocity control input for [UpdatedComponent]
     UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = Velocity)
-    FVector AngularVelocity = FVector::ZeroVector;
+    FRotator AngularVelocity = FRotator::ZeroRotator;
 
     //! Desired position calculated from deltatime and UpdatedComponent::ComponentVelocity
     //! @sa

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -348,7 +348,7 @@ public:
 
     //! [deg/s] Local target angular vel
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FVector TargetAngularVel = FVector::ZeroVector;
+    FRotator TargetAngularVel = FRotator::ZeroRotator;
 
     /**
      * @brief Stop robot movement, resetting all vel inputs
@@ -392,7 +392,7 @@ public:
      * @param InAngularVel
      */
     UFUNCTION(BlueprintCallable)
-    virtual void SetAngularVel(const FVector& InAngularVel);
+    virtual void SetAngularVel(const FRotator& InAngularVel);
 
     /**
      * @brief Set position and linear velocity to the robot in the server.
@@ -418,7 +418,7 @@ public:
     UFUNCTION(BlueprintCallable)
     virtual void SyncServerAngularMovement(float InClientTimeStamp,
                                            const FRotator& InClientRobotRotation,
-                                           const FVector& InAngularVel);
+                                           const FRotator& InAngularVel);
 
     /**
      * @brief Set linear velocity to #RobotVehicleMoveComponent in the client.
@@ -434,7 +434,7 @@ public:
      * @sa [Connection](https://docs.unrealengine.com/5.1/en-US/InteractiveExperiences/Networking/Actors/OwningConnections)
      */
     UFUNCTION(BlueprintCallable)
-    virtual void SetLocalAngularVel(const FVector& InAngularVel);
+    virtual void SetLocalAngularVel(const FRotator& InAngularVel);
 
     //! Offset transform between the Actor  root component and the pose that will be published in /odom topic
     UPROPERTY(EditAnywhere, BlueprintReadWrite)

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -346,9 +346,9 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     FVector TargetLinearVel = FVector::ZeroVector;
 
-    //! [deg/s] Local target angular vel
+    //! [deg/s] Local target angular vel [X:Roll - Y:Pitch - Z: Yaw]
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FRotator TargetAngularVel = FRotator::ZeroRotator;
+    FVector TargetAngularVel = FVector::ZeroVector;
 
     /**
      * @brief Stop robot movement, resetting all vel inputs
@@ -392,7 +392,7 @@ public:
      * @param InAngularVel
      */
     UFUNCTION(BlueprintCallable)
-    virtual void SetAngularVel(const FRotator& InAngularVel);
+    virtual void SetAngularVel(const FVector& InAngularVel);
 
     /**
      * @brief Set position and linear velocity to the robot in the server.
@@ -418,7 +418,7 @@ public:
     UFUNCTION(BlueprintCallable)
     virtual void SyncServerAngularMovement(float InClientTimeStamp,
                                            const FRotator& InClientRobotRotation,
-                                           const FRotator& InAngularVel);
+                                           const FVector& InAngularVel);
 
     /**
      * @brief Set linear velocity to #RobotVehicleMoveComponent in the client.
@@ -434,7 +434,7 @@ public:
      * @sa [Connection](https://docs.unrealengine.com/5.1/en-US/InteractiveExperiences/Networking/Actors/OwningConnections)
      */
     UFUNCTION(BlueprintCallable)
-    virtual void SetLocalAngularVel(const FRotator& InAngularVel);
+    virtual void SetLocalAngularVel(const FVector& InAngularVel);
 
     //! Offset transform between the Actor  root component and the pose that will be published in /odom topic
     UPROPERTY(EditAnywhere, BlueprintReadWrite)


### PR DESCRIPTION
* ROS twist msg's angular is in `rad` as SI unit https://www.ros.org/reps/rep-0103.html#units
* UE angular vel has been in `deg` to be consistent with `FRotator`, which is in `deg`
-> Conversion is done [here](https://github.com/rapyuta-robotics/RapyutaSimulationPlugins/blob/devel/Source/RapyutaSimulationPlugins/Private/Robots/RRRobotROS2Interface.cpp#L301) as receiving Twist msg
This PRs set `ARRBaseRobot/URobotVehicleMovementComponent`'s AngularVelocity to Degree for clarity in its usage

NOTE:
In DifferentialDriveComponent/RobotVehicleMovementComponent's UpdateMovement(), which is called per tick, `DegreesToRadians(AngularVel.Yaw)` is now needed for the calculation.
-> This could be avoided by using a local member `AngularVelRad`, however it could also cause a bit more overheads on maintenance, which is left to be considered.