### PR TITLE
Add BP Robot model data table loading

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -13,6 +13,7 @@ TMap<ERRResourceDataType, TArray<const TCHAR*>> URRGameSingleton::SASSET_OWNING_
     {ERRResourceDataType::UE_PHYSICS_ASSET, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
     {ERRResourceDataType::UE_MATERIAL, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
     {ERRResourceDataType::UE_TEXTURE, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
+    {ERRResourceDataType::UE_DATA_TABLE, {URRGameSingleton::ASSETS_PROJECT_MODULE_NAME, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME}},
 };
 
 URRGameSingleton::URRGameSingleton()
@@ -89,6 +90,9 @@ bool URRGameSingleton::InitializeResources()
 
     // [TEXTURE] --
     RequestResourcesLoading<ERRResourceDataType::UE_TEXTURE>();
+
+    // [DATATABLE] --
+    RequestResourcesLoading<ERRResourceDataType::UE_DATA_TABLE>();
 
     // [BODY SETUP] --
     // Body setups are dynamically created in runtime only

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRSDFParser.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRSDFParser.cpp
@@ -55,7 +55,9 @@ FRRRobotModelInfo FRRSDFParser::LoadModelInfoFromFile(const FString& InSDFPath)
         return FRRRobotModelInfo();
     }
 
+#if RAPYUTA_SDF_PARSER_DEBUG
     UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("PARSE SDF CONTENT FROM FILE %s"), *InSDFPath);
+#endif
     FRRRobotModelInfo robotModelInfo;
     auto& robotModelData = robotModelInfo.Data;
     robotModelData.ModelDescType = ERRRobotDescriptionType::SDF;
@@ -134,7 +136,9 @@ bool FRRSDFParser::LoadChildModelsData(const sdf::ElementPtr& InParentElement, F
         // To make sure each of [ModelNameList] is unique
         FString modelFullName = FString::Printf(TEXT("%s%s"), *OutRobotModelData.WorldName, *modelName);
         ensure(false == OutRobotModelData.ModelNameList.Contains(modelName));
+#if RAPYUTA_SDF_PARSER_DEBUG
         UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Model %s"), *modelName);
+#endif
 
         FRRRobotModelData modelData({modelFullName});
         modelData.ModelDescType = ERRRobotDescriptionType::SDF;

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRSDFParser.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRSDFParser.cpp
@@ -57,14 +57,15 @@ FRRRobotModelInfo FRRSDFParser::LoadModelInfoFromFile(const FString& InSDFPath)
 
     UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("PARSE SDF CONTENT FROM FILE %s"), *InSDFPath);
     FRRRobotModelInfo robotModelInfo;
-    robotModelInfo.ModelDescType = ERRRobotDescriptionType::SDF;
-    robotModelInfo.DescriptionFilePath = InSDFPath;
+    auto& robotModelData = robotModelInfo.Data;
+    robotModelData.ModelDescType = ERRRobotDescriptionType::SDF;
+    robotModelData.DescriptionFilePath = InSDFPath;
     if (LoadModelInfoFromSDF(outSDFContent, robotModelInfo))
     {
-        robotModelInfo.UpdateLinksLocationFromJoints();
+        robotModelData.UpdateLinksLocationFromJoints();
 #if RAPYUTA_SDF_PARSER_DEBUG
         UE_LOG_WITH_INFO(
-            LogRapyutaCore, Warning, TEXT("PARSING SDF SUCCEEDED[%s]!"), *FString::Join(robotModelInfo.ModelNameList, TEXT(",")));
+            LogRapyutaCore, Warning, TEXT("PARSING SDF SUCCEEDED[%s]!"), *FString::Join(robotModelData.ModelNameList, TEXT(",")));
 #endif
     }
     else
@@ -86,32 +87,34 @@ bool FRRSDFParser::LoadModelInfoFromSDF(const sdf::SDFPtr& InSDFContent, FRRRobo
     }
 
     bool bResult = true;
+    FRRRobotModelData& outRobotModelData = OutRobotModelInfo.Data;
+
     const sdf::ElementPtr topElement = rootElement->GetFirstElement();
     // World
     if (worldElement == topElement)
     {
-        OutRobotModelInfo.WorldName = URRCoreUtils::StdToFString(worldElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
+        outRobotModelData.WorldName = URRCoreUtils::StdToFString(worldElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
 
         // World's Child Models info
-        bResult &= LoadChildModelsInfo(worldElement, OutRobotModelInfo);
+        bResult &= LoadChildModelsData(worldElement, outRobotModelData);
     }
 
     // Model
     else if (modelElement == topElement)
     {
-        OutRobotModelInfo.ModelNameList.Emplace(URRCoreUtils::StdToFString(modelElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME)));
+        outRobotModelData.ModelNameList.Emplace(URRCoreUtils::StdToFString(modelElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME)));
 
         // Model's pose info
-        bResult &= LoadPoseInfo(modelElement, OutRobotModelInfo);
+        bResult &= LoadPoseInfo(modelElement, outRobotModelData);
 
         // Model's UE components info
-        bResult &= ParseModelUESpecifics(modelElement, OutRobotModelInfo);
+        bResult &= ParseModelUESpecifics(modelElement, outRobotModelData);
 
         // Model's links/joints info
-        bResult &= LoadLinksJointsInfo(modelElement, OutRobotModelInfo);
+        bResult &= LoadLinksJointsInfo(modelElement, outRobotModelData);
 
         // Model's Child Models info
-        bResult &= LoadChildModelsInfo(modelElement, OutRobotModelInfo);
+        bResult &= LoadChildModelsData(modelElement, outRobotModelData);
     }
 
     // Clear temp read data
@@ -119,7 +122,7 @@ bool FRRSDFParser::LoadModelInfoFromSDF(const sdf::SDFPtr& InSDFContent, FRRRobo
     return bResult;
 }
 
-bool FRRSDFParser::LoadChildModelsInfo(const sdf::ElementPtr& InParentElement, FRRRobotModelInfo& OutRobotModelInfo)
+bool FRRSDFParser::LoadChildModelsData(const sdf::ElementPtr& InParentElement, FRRRobotModelData& OutRobotModelData)
 {
     bool bResult = true;
     // Read <model> tags
@@ -129,25 +132,25 @@ bool FRRSDFParser::LoadChildModelsInfo(const sdf::ElementPtr& InParentElement, F
         const FString modelName = URRCoreUtils::StdToFString(childModelElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
 
         // To make sure each of [ModelNameList] is unique
-        FString modelFullName = FString::Printf(TEXT("%s%s"), *OutRobotModelInfo.WorldName, *modelName);
-        verify(false == OutRobotModelInfo.ModelNameList.Contains(modelName));
+        FString modelFullName = FString::Printf(TEXT("%s%s"), *OutRobotModelData.WorldName, *modelName);
+        ensure(false == OutRobotModelData.ModelNameList.Contains(modelName));
         UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Model %s"), *modelName);
 
-        FRRRobotModelInfo modelInfo({modelFullName});
-        modelInfo.ModelDescType = ERRRobotDescriptionType::SDF;
+        FRRRobotModelData modelData({modelFullName});
+        modelData.ModelDescType = ERRRobotDescriptionType::SDF;
 
         // 1- ChildModel's pose info
-        bResult &= LoadPoseInfo(childModelElement, modelInfo);
+        bResult &= LoadPoseInfo(childModelElement, modelData);
 
         // 2- ChildModel's Links/Joints info
-        bResult &= LoadLinksJointsInfo(childModelElement, modelInfo);
+        bResult &= LoadLinksJointsInfo(childModelElement, modelData);
 
         // 3- ChildModel's UE components info, which requires prior Links/Joints info
-        bResult &= ParseModelUESpecifics(childModelElement, modelInfo);
+        bResult &= ParseModelUESpecifics(childModelElement, modelData);
 
-        // Update [ChildModelsInfo] & [ModelNameList]
-        OutRobotModelInfo.ChildModelsInfo.Emplace(MoveTemp(modelInfo));
-        OutRobotModelInfo.ModelNameList.Emplace(MoveTemp(modelFullName));
+        // Update [ChildModelsData] & [ModelNameList]
+        OutRobotModelData.ChildModelsData.Emplace(MoveTemp(modelData));
+        OutRobotModelData.ModelNameList.Emplace(MoveTemp(modelFullName));
 
         // Move to next <model>
         childModelElement = childModelElement->GetNextElement(SDF_ELEMENT_MODEL);
@@ -155,21 +158,21 @@ bool FRRSDFParser::LoadChildModelsInfo(const sdf::ElementPtr& InParentElement, F
     return true;
 }
 
-bool FRRSDFParser::LoadPoseInfo(const sdf::ElementPtr& InElement, FRRRobotModelInfo& OutRobotModelInfo)
+bool FRRSDFParser::LoadPoseInfo(const sdf::ElementPtr& InElement, FRRRobotModelData& OutRobotModelData)
 {
     const auto poseElement = InElement->FindElement(SDF_ELEMENT_POSE);
     if (poseElement)
     {
-        OutRobotModelInfo.ParentFrameName = URRCoreUtils::StdToFString(poseElement->Get<std::string>(SDF_ELEMENT_ATTR_RELATIVE_TO));
+        OutRobotModelData.ParentFrameName = URRCoreUtils::StdToFString(poseElement->Get<std::string>(SDF_ELEMENT_ATTR_RELATIVE_TO));
 
         const auto poseOffset = poseElement->Get<ignition::math::Pose3d>();
-        OutRobotModelInfo.RelativeTransform.SetLocation(GetLocationFromIgnitionPose(poseOffset));
-        OutRobotModelInfo.RelativeTransform.SetRotation(GetRotationFromIgnitionPose(poseOffset));
+        OutRobotModelData.RelativeTransform.SetLocation(GetLocationFromIgnitionPose(poseOffset));
+        OutRobotModelData.RelativeTransform.SetRotation(GetRotationFromIgnitionPose(poseOffset));
     }
     return true;
 }
 
-bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, FRRRobotModelInfo& OutRobotModelInfo)
+bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, FRRRobotModelData& OutRobotModelData)
 {
     sdf::ElementPtr ueElement = InModelElement->FindElement(SDF_ELEMENT_UE);
     if (nullptr == ueElement)
@@ -186,7 +189,7 @@ bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, 
             TEXT("ERRUEComponentType"), URRCoreUtils::StdToFString(componentElement->Get<std::string>(SDF_ELEMENT_ATTR_TYPE)));
         if (componentTypeVal != INDEX_NONE)
         {
-            OutRobotModelInfo.SetUEComponentEnabled(componentTypeVal);
+            OutRobotModelData.SetUEComponentEnabled(componentTypeVal);
         }
 
         componentElement = componentElement->GetNextElement(SDF_ELEMENT_COMPONENT);
@@ -195,16 +198,16 @@ bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, 
     // 2- Base link name
     if (auto baseLinkElement = ueElement->FindElement(SDF_ELEMENT_BASE_LINK))
     {
-        OutRobotModelInfo.BaseLinkName = URRCoreUtils::StdToFString(baseLinkElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
+        OutRobotModelData.BaseLinkName = URRCoreUtils::StdToFString(baseLinkElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
     }
 
-    // 3- Articulated links, which uses OutRobotModelInfo.UEComponentTypeFlags
-    if (OutRobotModelInfo.IsPlainManipulatorModel())
+    // 3- Articulated links, which uses OutRobotModelData.UEComponentTypeFlags
+    if (OutRobotModelData.IsPlainManipulatorModel())
     {
         // By default all links are articulated for ARTICULATION_DRIVE-only manipulator type
-        for (const auto& linkProp : OutRobotModelInfo.LinkPropList)
+        for (const auto& linkProp : OutRobotModelData.LinkPropList)
         {
-            OutRobotModelInfo.ArticulatedLinksNames.Add(linkProp.Name);
+            OutRobotModelData.ArticulatedLinksNames.Add(linkProp.Name);
         }
     }
     else
@@ -216,20 +219,20 @@ bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, 
             FString arLinkName = URRCoreUtils::StdToFString(articulatedElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
             if (false == arLinkName.IsEmpty())
             {
-                OutRobotModelInfo.ArticulatedLinksNames.Emplace(MoveTemp(arLinkName));
+                OutRobotModelData.ArticulatedLinksNames.Emplace(MoveTemp(arLinkName));
             }
 
             articulatedElement = articulatedElement->GetNextElement(SDF_ELEMENT_ARTICULATED_LINK);
         }
     }
 
-    // 4- Wheels, which uses OutRobotModelInfo.UEComponentTypeFlags
-    if (OutRobotModelInfo.IsPlainWheeledVehicleModel())
+    // 4- Wheels, which uses OutRobotModelData.UEComponentTypeFlags
+    if (OutRobotModelData.IsPlainWheeledVehicleModel())
     {
         // By default all links are articulated for WHEEL_DRIVE-only vehicle type
-        for (const auto& linkProp : OutRobotModelInfo.LinkPropList)
+        for (const auto& linkProp : OutRobotModelData.LinkPropList)
         {
-            OutRobotModelInfo.WheelPropList.Emplace(FRRRobotWheelProperty(linkProp.Name));
+            OutRobotModelData.WheelPropList.Emplace(FRRRobotWheelProperty(linkProp.Name));
         }
     }
     else
@@ -241,7 +244,7 @@ bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, 
             FString wheelName = URRCoreUtils::StdToFString(wheelElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
             if (false == wheelName.IsEmpty())
             {
-                OutRobotModelInfo.WheelPropList.Emplace(FRRRobotWheelProperty(MoveTemp(wheelName)));
+                OutRobotModelData.WheelPropList.Emplace(FRRRobotWheelProperty(MoveTemp(wheelName)));
             }
 
             wheelElement = wheelElement->GetNextElement(SDF_ELEMENT_WHEEL);
@@ -255,7 +258,7 @@ bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, 
         FString eeName = URRCoreUtils::StdToFString(endEffectorElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
         if (false == eeName.IsEmpty())
         {
-            OutRobotModelInfo.EndEffectorNames.Emplace(MoveTemp(eeName));
+            OutRobotModelData.EndEffectorNames.Emplace(MoveTemp(eeName));
         }
 
         endEffectorElement = endEffectorElement->GetNextElement(SDF_ELEMENT_END_EFFECTOR);
@@ -265,12 +268,12 @@ bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, 
     sdf::ElementPtr staticMeshElement = ueElement->FindElement(SDF_ELEMENT_LINK_STATIC_MESH);
     if (staticMeshElement)
     {
-        OutRobotModelInfo.WholeBodyStaticMeshName =
+        OutRobotModelData.WholeBodyStaticMeshName =
             URRCoreUtils::StdToFString(staticMeshElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
     }
 
     // 7- WholeBody's material
-    auto& materialInfo = OutRobotModelInfo.WholeBodyMaterialInfo;
+    auto& materialInfo = OutRobotModelData.WholeBodyMaterialInfo;
     sdf::ElementPtr materialElement = ueElement->FindElement(SDF_ELEMENT_LINK_MATERIAL);
     if (materialElement)
     {
@@ -304,19 +307,19 @@ bool FRRSDFParser::ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, 
     return true;
 }
 
-bool FRRSDFParser::LoadLinksJointsInfo(const sdf::ElementPtr& InParentElement, FRRRobotModelInfo& OutRobotModelInfo)
+bool FRRSDFParser::LoadLinksJointsInfo(const sdf::ElementPtr& InParentElement, FRRRobotModelData& OutRobotModelData)
 {
     // Link elements
-    bool bResult = ParseLinksProperty(InParentElement, OutRobotModelInfo);
+    bool bResult = ParseLinksProperty(InParentElement, OutRobotModelData);
     if (bResult)
     {
         // Joint elements
-        bResult = ParseJointsProperty(InParentElement, OutRobotModelInfo);
+        bResult = ParseJointsProperty(InParentElement, OutRobotModelData);
     }
     return bResult;
 }
 
-bool FRRSDFParser::ParseLinksProperty(const sdf::ElementPtr& InModelElement, FRRRobotModelInfo& OutRobotModelInfo)
+bool FRRSDFParser::ParseLinksProperty(const sdf::ElementPtr& InModelElement, FRRRobotModelData& OutRobotModelData)
 {
     sdf::ElementPtr linkElement = InModelElement->FindElement(SDF_ELEMENT_LINK);
     while (linkElement)
@@ -395,7 +398,7 @@ bool FRRSDFParser::ParseLinksProperty(const sdf::ElementPtr& InModelElement, FRR
         ParseSensorsProperty(linkElement, newLinkProp.SensorList);
 
         // Add new link prop to the list
-        OutRobotModelInfo.LinkPropList.Emplace(MoveTemp(newLinkProp));
+        OutRobotModelData.LinkPropList.Emplace(MoveTemp(newLinkProp));
 
         linkElement = linkElement->GetNextElement(SDF_ELEMENT_LINK);
     }
@@ -404,8 +407,8 @@ bool FRRSDFParser::ParseLinksProperty(const sdf::ElementPtr& InModelElement, FRR
 
 bool FRRSDFParser::ParseGeometryInfo(const sdf::ElementPtr& InLinkElement,
                                      const ERRRobotGeometryType InGeometryType,
-                                     FVector LocationBase,
-                                     FQuat RotationBase,
+                                     const FVector& InLocationBase,
+                                     const FQuat& InRotationBase,
                                      TArray<FRRRobotGeometryInfo>& OutGeometryInfoList)
 {
     const FString linkName = URRCoreUtils::StdToFString(InLinkElement->Get<std::string>(SDF_ELEMENT_ATTR_NAME));
@@ -434,8 +437,8 @@ bool FRRSDFParser::ParseGeometryInfo(const sdf::ElementPtr& InLinkElement,
         }
         else
         {
-            geometryInfo.Location = LocationBase;
-            geometryInfo.Rotation = RotationBase;
+            geometryInfo.Location = InLocationBase;
+            geometryInfo.Rotation = InRotationBase;
         }
 
         // Geometry
@@ -641,7 +644,7 @@ bool FRRSDFParser::ParseSensorsProperty(const sdf::ElementPtr& InLinkElement, TA
     return true;
 }
 
-bool FRRSDFParser::ParseJointsProperty(const sdf::ElementPtr& InModelElement, FRRRobotModelInfo& OutRobotModelInfo)
+bool FRRSDFParser::ParseJointsProperty(const sdf::ElementPtr& InModelElement, FRRRobotModelData& OutRobotModelData)
 {
     sdf::ElementPtr jointElement = InModelElement->FindElement(SDF_ELEMENT_JOINT);
     while (jointElement)
@@ -655,7 +658,7 @@ bool FRRSDFParser::ParseJointsProperty(const sdf::ElementPtr& InModelElement, FR
             UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("Ignore attached-to-world-link joint!"));
 #endif
             jointElement = jointElement->GetNextElement(SDF_ELEMENT_JOINT);
-            OutRobotModelInfo.bHasWorldJoint = true;
+            OutRobotModelData.bHasWorldJoint = true;
             continue;
         }
 
@@ -739,7 +742,7 @@ bool FRRSDFParser::ParseJointsProperty(const sdf::ElementPtr& InModelElement, FR
         }
 
         // Add new joint data to the list
-        OutRobotModelInfo.JointPropList.Emplace(MoveTemp(newJointProp));
+        OutRobotModelData.JointPropList.Emplace(MoveTemp(newJointProp));
 
         jointElement = jointElement->GetNextElement(SDF_ELEMENT_JOINT);
     }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
@@ -333,7 +333,7 @@ UStaticMesh* URRStaticMeshComponent::CreateMeshBody(const FRRMeshData& InMeshDat
         {
 #endif
             URRAssetUtils::SaveObjectToAssetInModule(
-                visualMesh, ERRResourceDataType::UE_STATIC_MESH, MeshUniqueName, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME, false);
+                visualMesh, ERRResourceDataType::UE_STATIC_MESH, MeshUniqueName, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME);
 #if WITH_EDITOR
         }
         else

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRURDFParser.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRURDFParser.cpp
@@ -809,7 +809,9 @@ FRRRobotModelInfo FRRURDFParser::LoadModelInfoFromFile(const FString& InURDFPath
     }
     outXMLContent = URRCoreUtils::GetSanitizedXMLString(outXMLContent);
 
+#if RAPYUTA_URDF_PARSER_DEBUG
     UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("PARSE URDF CONTENT FROM FILE %s"), *InURDFPath);
+#endif
     FRRRobotModelInfo robotModelInfo;
     auto& robotModelData = robotModelInfo.Data;
     robotModelData.ModelDescType = ERRRobotDescriptionType::URDF;

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRURDFParser.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRURDFParser.cpp
@@ -811,11 +811,12 @@ FRRRobotModelInfo FRRURDFParser::LoadModelInfoFromFile(const FString& InURDFPath
 
     UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("PARSE URDF CONTENT FROM FILE %s"), *InURDFPath);
     FRRRobotModelInfo robotModelInfo;
-    robotModelInfo.ModelDescType = ERRRobotDescriptionType::URDF;
-    robotModelInfo.DescriptionFilePath = InURDFPath;
+    auto& robotModelData = robotModelInfo.Data;
+    robotModelData.ModelDescType = ERRRobotDescriptionType::URDF;
+    robotModelData.DescriptionFilePath = InURDFPath;
     if (LoadModelInfoFromXML(outXMLContent, robotModelInfo))
     {
-        robotModelInfo.UpdateLinksLocationFromJoints();
+        robotModelData.UpdateLinksLocationFromJoints();
     }
     return robotModelInfo;
 }
@@ -844,40 +845,41 @@ bool FRRURDFParser::LoadModelInfoFromXML(const FString& InUrdfXml, FRRRobotModel
 #if RAPYUTA_URDF_PARSER_DEBUG
         UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("PARSING URDF SUCCEEDED[%s]!"), *ModelName);
 #endif
-        OutRobotModelInfo.ModelNameList.Emplace(MoveTemp(ModelName));
-        OutRobotModelInfo.bHasWorldJoint = bHasWorldJoint;
-        OutRobotModelInfo.UEComponentTypeFlags = UEComponentTypeFlags;
+        FRRRobotModelData& outRobotModelData = OutRobotModelInfo.Data;
+        outRobotModelData.ModelNameList.Emplace(MoveTemp(ModelName));
+        outRobotModelData.bHasWorldJoint = bHasWorldJoint;
+        outRobotModelData.UEComponentTypeFlags = UEComponentTypeFlags;
 
         // 0- BaseLink
-        OutRobotModelInfo.BaseLinkName = MoveTemp(BaseLinkName);
+        outRobotModelData.BaseLinkName = MoveTemp(BaseLinkName);
 
         // 1- Links/Joints
-        OutRobotModelInfo.LinkPropList = MoveTemp(LinkPropList);
-        OutRobotModelInfo.JointPropList = MoveTemp(JointPropList);
+        outRobotModelData.LinkPropList = MoveTemp(LinkPropList);
+        outRobotModelData.JointPropList = MoveTemp(JointPropList);
 
         // 2- ArticulatedLinksNames
         // [Manipulator] as containing ARTICULATION_DRIVE only
         if (IsPlainManipulatorModel())
         {
             // By default all links are articulated for ARTICULATION_DRIVE-only manipulator type
-            for (const auto& linkProp : OutRobotModelInfo.LinkPropList)
+            for (const auto& linkProp : outRobotModelData.LinkPropList)
             {
-                OutRobotModelInfo.ArticulatedLinksNames.Add(linkProp.Name);
+                outRobotModelData.ArticulatedLinksNames.Add(linkProp.Name);
             }
         }
         else
         {
-            OutRobotModelInfo.ArticulatedLinksNames = MoveTemp(ArticulatedLinksNames);
+            outRobotModelData.ArticulatedLinksNames = MoveTemp(ArticulatedLinksNames);
         }
 
         // 3- WheelsNames
-        OutRobotModelInfo.WheelPropList = MoveTemp(WheelPropList);
+        outRobotModelData.WheelPropList = MoveTemp(WheelPropList);
 
         // 4- EndEffectorNames
-        OutRobotModelInfo.EndEffectorNames = MoveTemp(EndEffectorNames);
+        outRobotModelData.EndEffectorNames = MoveTemp(EndEffectorNames);
 
         // 4- WholeBodyMaterialInfo
-        OutRobotModelInfo.WholeBodyMaterialInfo = MoveTemp(WholeBodyMaterialInfo);
+        outRobotModelData.WholeBodyMaterialInfo = MoveTemp(WholeBodyMaterialInfo);
     }
     else
     {

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -90,7 +90,7 @@ enum class ERRFileType : uint8
 UENUM()
 enum class ERRShapeType : uint8
 {
-    INVALID,
+    NONE,
     PLANE,
     BOX,
     CYLINDER,

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -46,8 +46,11 @@ using URRAssetObject = typename TChooseClass<
                     typename TChooseClass<
                         (ERRResourceDataType::UE_TEXTURE == InDataType),
                         UTexture,
-                        typename TChooseClass<(ERRResourceDataType::UE_BODY_SETUP == InDataType), UBodySetup, UObject>::Result>::
-                        Result>::Result>::Result>::Result>::Result>::Result;
+                        typename TChooseClass<
+                            (ERRResourceDataType::UE_DATA_TABLE == InDataType),
+                            UDataTable,
+                            typename TChooseClass<(ERRResourceDataType::UE_BODY_SETUP == InDataType), UBodySetup, UObject>::
+                                Result>::Result>::Result>::Result>::Result>::Result>::Result>::Result;
 
 /**
  * @brief GameSingleton class which handles asset loading.
@@ -128,6 +131,12 @@ public:
             case ERRResourceDataType::UE_TEXTURE:
                 return TEXT("T_");
 
+            case ERRResourceDataType::UE_DATA_TABLE:
+                return TEXT("DT_");
+
+            case ERRResourceDataType::UE_BODY_SETUP:
+                return TEXT("BS_");
+
             default:
                 return EMPTY_STR;
         }
@@ -174,6 +183,9 @@ public:
 
             case ERRResourceDataType::UE_TEXTURE:
                 return FOLDER_PATH_ASSET_TEXTURES;
+
+            case ERRResourceDataType::UE_DATA_TABLE:
+                return FOLDER_PATH_ASSET_DATA_TABLES;
 
             default:
                 return EMPTY_STR;
@@ -367,6 +379,10 @@ public:
 
             case ERRResourceDataType::UE_TEXTURE:
                 ProcessAsyncLoadedResource<UTexture>(InDataType, InResourcePath, InResourceUniqueName);
+                break;
+
+            case ERRResourceDataType::UE_DATA_TABLE:
+                ProcessAsyncLoadedResource<UDataTable>(InDataType, InResourcePath, InResourceUniqueName);
                 break;
 
             default:
@@ -710,6 +726,22 @@ public:
     FORCEINLINE UTexture* GetTexture(const FString& InTextureName, bool bIsStaticResource = true) const
     {
         return GetSimResource<UTexture>(ERRResourceDataType::UE_TEXTURE, InTextureName, bIsStaticResource);
+    }
+
+    // DATA TABLES --
+    //! Dynamic Data Table assets folder path
+    UPROPERTY(config)
+    FString FOLDER_PATH_ASSET_DATA_TABLES = TEXT("DataTables");
+
+    /**
+     * @brief Call #GetSimResource with #ERRResourceDataType::UE_DATA_TABLE
+     * @param InDataTableName
+     * @param bIsStaticResource
+     * @return FORCEINLINE*
+     */
+    FORCEINLINE UDataTable* GetDataTable(const FString& InDataTableName, bool bIsStaticResource = true) const
+    {
+        return GetSimResource<UDataTable>(ERRResourceDataType::UE_DATA_TABLE, InDataTableName, bIsStaticResource);
     }
 
     // BODY SETUPS --

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -302,10 +302,8 @@ public:
         if (0 == CollateAssetsInfo<URRAssetObject<InDataType>>(InDataType, GetAssetsFolderName(InDataType)))
         {
             resourceInfo.bHasBeenAllLoaded = true;
-            UE_LOG_WITH_INFO(LogTemp,
-                             Warning,
-                             TEXT("THERE ARE NO [%s] TO BE LOADED."),
-                             *URRTypeUtils::GetERRResourceDataTypeAsString(InDataType));
+            UE_LOG_WITH_INFO(
+                LogTemp, Warning, TEXT("THERE IS NO [%s] TO BE LOADED"), *URRTypeUtils::GetERRResourceDataTypeAsString(InDataType));
             return true;
         }
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
@@ -33,6 +33,7 @@ enum class ERRResourceDataType : uint8
     UE_PHYSICS_ASSET,
     UE_MATERIAL,
     UE_TEXTURE,
+    UE_DATA_TABLE,
 
     // UOBJECT --
     // Cooked collision data
@@ -172,7 +173,7 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRResourceInfo
     }
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct RAPYUTASIMULATIONPLUGINS_API FRRMaterialProperty
 {
     // These property names are defined in master material by the artist

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRProceduralMeshComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRProceduralMeshComponent.h
@@ -47,13 +47,13 @@ public:
     }
 
     UPROPERTY()
-    ERRShapeType ShapeType = ERRShapeType::INVALID;
+    ERRShapeType ShapeType = ERRShapeType::NONE;
 
     /**
      * @brief CustomDepthStencil will be actively set by stakeholders or ARRMeshActor if needs be
-     * 
-     * @param bIsStaticBody 
-     * @param bInIsPhysicsEnabled 
+     *
+     * @param bIsStaticBody
+     * @param bInIsPhysicsEnabled
      */
     void Initialize(bool bIsStaticBody, bool bInIsPhysicsEnabled);
 
@@ -77,8 +77,8 @@ public:
 
     /**
      * @brief Create primitive-shape mesh based on #ShapeType.
-     * 
-     * @param InSize 
+     *
+     * @param InSize
      */
     void SetMeshSize(const FVector& InSize);
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRSDFParser.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRSDFParser.h
@@ -12,7 +12,7 @@
 
 /**
  * @brief [experimental] Parse SDF file and generate FRRRobotModelInfo. Uses ignition library to parse SDF file.
- * 
+ *
  */
 class RAPYUTASIMULATIONPLUGINS_API FRRSDFParser : public FRRRobotDescriptionParser
 {
@@ -21,18 +21,18 @@ public:
     bool LoadModelInfoFromSDF(const sdf::SDFPtr& InSDFContent, FRRRobotModelInfo& OutRobotModelInfo);
 
 private:
-    bool ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, FRRRobotModelInfo& OutRobotModelInfo);
+    bool ParseModelUESpecifics(const sdf::ElementPtr& InModelElement, FRRRobotModelData& OutRobotModelData);
     bool ParseGeometryInfo(const sdf::ElementPtr& InLinkElement,
                            const ERRRobotGeometryType InGeometryType,
-                           FVector LocationBase,
-                           FQuat RotationBase,
+                           const FVector& InLocationBase,
+                           const FQuat& InRotationBase,
                            TArray<FRRRobotGeometryInfo>& OutGeometryInfoList);
-    bool LoadChildModelsInfo(const sdf::ElementPtr& InParentElement, FRRRobotModelInfo& OutRobotModelInfo);
-    bool LoadPoseInfo(const sdf::ElementPtr& InElement, FRRRobotModelInfo& OutRobotModelInfo);
-    bool LoadLinksJointsInfo(const sdf::ElementPtr& InParentElement, FRRRobotModelInfo& OutRobotModelInfo);
-    bool ParseLinksProperty(const sdf::ElementPtr& InModelElement, FRRRobotModelInfo& OutRobotModelInfo);
+    bool LoadChildModelsData(const sdf::ElementPtr& InParentElement, FRRRobotModelData& OutRobotModelData);
+    bool LoadPoseInfo(const sdf::ElementPtr& InElement, FRRRobotModelData& OutRobotModelData);
+    bool LoadLinksJointsInfo(const sdf::ElementPtr& InParentElement, FRRRobotModelData& OutRobotModelData);
+    bool ParseLinksProperty(const sdf::ElementPtr& InModelElement, FRRRobotModelData& OutRobotModelData);
     bool ParseSensorsProperty(const sdf::ElementPtr& InLinkElement, TArray<FRRSensorProperty>& OutSensorPropList);
-    bool ParseJointsProperty(const sdf::ElementPtr& InModelElement, FRRRobotModelInfo& OutRobotModelInfo);
+    bool ParseJointsProperty(const sdf::ElementPtr& InModelElement, FRRRobotModelData& OutRobotModelData);
 
     static constexpr const char* SDF_ELEMENT_ATTR_NAME = "name";
     static constexpr const char* SDF_ELEMENT_ATTR_TYPE = "type";

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRStaticMeshComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRStaticMeshComponent.h
@@ -41,9 +41,9 @@ public:
      * @note Upon creation, DO NOT enable physics here yet, which will makes mesh comp detached from its parent.
      * Physics should only be enabled after children mesh comps have also been created, so they will be welded.
      * Refer to [FBodyInstance::SetInstanceSimulatePhysics()]
-     * 
-     * @param bInIsStationary 
-     * @param bInIsPhysicsEnabled 
+     *
+     * @param bInIsStationary
+     * @param bInIsPhysicsEnabled
      */
     void Initialize(bool bInIsStationary, bool bInIsPhysicsEnabled);
 
@@ -51,9 +51,9 @@ public:
      * @brief Initialize mesh. initialization is different based on mesh type, #ERRShapeType, which can be get from #URRGameSingleton::GetShapeTypeFromMeshName
      * Uses #URRThreadUtils::DoAsyncTaskInThread and #URRThreadUtils::DoTaskInGameThread to load Mesh
      * If ShapeType is not #ERRShapeType::MESH i.e. primitive-shape, initialization is done by #SetMesh
-     * @param InMeshFileName 
-     * @return true 
-     * @return false 
+     * @param InMeshFileName
+     * @return true
+     * @return false
      */
     bool InitializeMesh(const FString& InMeshFileName);
 
@@ -70,16 +70,16 @@ public:
     /**
      * @brief Create a Mesh Body object
      * @note This function could be invoked from an async task running in GameThread
-     * @param InMeshData 
-     * @return UStaticMesh* 
+     * @param InMeshData
+     * @return UStaticMesh*
      */
     UStaticMesh* CreateMeshBody(const FRRMeshData& InMeshData);
 
     /**
      * @brief Set Static mesh from UstaticMesh
      * @sa [SetStaticMesh](https://docs.unrealengine.com/5.1/en-US/API/Runtime/Engine/Components/UStaticMeshComponent/SetStaticMesh/)
-     * 
-     * @param InStaticMesh 
+     *
+     * @param InStaticMesh
      */
     void SetMesh(UStaticMesh* InStaticMesh);
 
@@ -89,7 +89,7 @@ public:
     }
 
     UPROPERTY()
-    ERRShapeType ShapeType = ERRShapeType::INVALID;
+    ERRShapeType ShapeType = ERRShapeType::NONE;
 
     UPROPERTY()
     FTransform OriginRelativeTransform;
@@ -121,16 +121,16 @@ public:
 
     /**
      * @brief Get the Size of bounding box of the mesh.
-     * 
-     * @return FVector 
+     *
+     * @return FVector
      */
     UFUNCTION()
     FVector GetSize() const;
 
     /**
      * @brief Get the extent of bounding box of the mesh.
-     * 
-     * @return FVector 
+     *
+     * @return FVector
      */
     UFUNCTION()
     FVector GetExtent() const;
@@ -152,8 +152,8 @@ public:
     /**
      * @brief Set the Collision Mode with some preset parameters
      * @todo is preset parameter cover all use case?
-     * @param bInCollisionEnabled 
-     * @param bInHitEventEnabled 
+     * @param bInCollisionEnabled
+     * @param bInHitEventEnabled
      */
     UFUNCTION()
     void SetCollisionModeAvailable(bool bInCollisionEnabled, bool bInHitEventEnabled = false);
@@ -163,7 +163,7 @@ public:
 
 protected:
     /**
-    * @brief 
+    * @brief
     * It is considered that a mesh component should only be physically activated if its Owning Actor is Physically Enabled,
     * thus not auto activating physics here! Rather, it is left to the Owning actor to do it!
     */

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
@@ -98,8 +98,7 @@ enum class ERRRobotJointType : uint8
 UENUM()
 enum class ERRRobotJointStatus : uint8
 {
-    // Invalid -> Idle: After joint drive params are fully configured
-    INVALID,
+    INVALID,    //! Invalid -> Idle: After joint drive params are fully configured
     IDLE,
     MOVING,
     TOTAL
@@ -152,17 +151,16 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRRobotJointDynamicProperties
     UPROPERTY(EditAnywhere)
     FString JointName;
     // For Spring-Damper Control Mode --
-    // Stiffness
+    //! [Stiffness](https://docs.unrealengine.com/5.2/en-US/physics-damping-in-unreal-engine)
     UPROPERTY(EditAnywhere,
               Category = "Spring-Damper",
               meta = (ClampMin = "0.0", ClampMax = "1000000000.0", UIMin = "0.0", UIMax = "1000000000.0"))
     float SpringStiff = 0.f;
-    // https://docs.unrealengine.com/en-us/Engine/Physics/FrictionRestitutionAndDamping
     UPROPERTY(EditAnywhere,
               Category = "Spring-Damper",
               meta = (ClampMin = "0.0", ClampMax = "1000000000.0", UIMin = "0.0", UIMax = "1000000000.0"))
     float LimitSpringStiff = 0.f;
-    // Damping
+    //! [Damping](https://docs.unrealengine.com/5.2/en-US/physics-damping-in-unreal-engine)
     UPROPERTY(EditAnywhere,
               Category = "Spring-Damper",
               meta = (ClampMin = "0.0", ClampMax = "500.0", UIMin = "0.0", UIMax = "500.0"))
@@ -184,7 +182,7 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRRobotJointDynamicProperties
               meta = (ClampMin = "0.0", ClampMax = "10000000.0", UIMin = "0.0", UIMax = "10000000.0"))
     float MaxForceLimit = 100000000.f;
 
-    //! Rad(m)/s
+    //! [rad/s or m/s]
     UPROPERTY(EditAnywhere)
     float MaxVelocity = 1000000.f;
 
@@ -244,11 +242,11 @@ public:
     UPROPERTY(VisibleAnywhere)
     ERRRobotJointStatus Status = ERRRobotJointStatus::INVALID;
 
-    //! In URDF/SDF: Child Link's relative Location to its Parent
+    //! [cm] In URDF/SDF: Child Link's relative Location to its Parent
     UPROPERTY(EditAnywhere)
     FVector Location = FVector::ZeroVector;
 
-    //! In URDF/SDF: Child Link's relative Rotation to its Parent
+    //! [Quaternion] In URDF/SDF: Child Link's relative Rotation to its Parent
     UPROPERTY(EditAnywhere)
     FQuat Rotation = FQuat::Identity;
 
@@ -268,6 +266,7 @@ public:
     FString MimicJointName;
     UPROPERTY(EditAnywhere)
     float MimicMultiplier = 1.0f;
+    //! [cm]
     UPROPERTY(EditAnywhere)
     float MimicOffset = 0.0f;
     UPROPERTY(EditAnywhere)
@@ -449,6 +448,9 @@ public:
     }
 };
 
+/**
+ * @brief Joint value struct, mainly to directly store input values from ROS cmds, thus units are in SI to avoid conversion overheads
+ */
 USTRUCT(BlueprintType)
 struct RAPYUTASIMULATIONPLUGINS_API FRRRobotJointValue
 {
@@ -456,14 +458,17 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRRobotJointValue
     //! [rad] for REVOLUTE joint, [m] for Prismatic Joint
     UPROPERTY(EditAnywhere, meta = (ToopTip = "rad or m", ClampMin = "-100.0", ClampMax = "100.0", UIMin = "-100", UIMax = "100.0"))
     double Position = 0;
+    //! [m/s]
     UPROPERTY(EditAnywhere, meta = (ToopTip = "m/s", ClampMin = "-100.0", ClampMax = "100.0", UIMin = "-100.0", UIMax = "100.0"))
     double LinearVel = 0;
+    //! [rad/s]
     UPROPERTY(EditAnywhere, meta = (ToopTip = "rad/s", ClampMin = "-10.0", ClampMax = "10.0", UIMin = "-10.0", UIMax = "10.0"))
     double AngularVel = 0;
 
     FString ToString() const
     {
-        return FString::Printf(TEXT("Pos: %lf LinearVel: %lf AngularVel: %lf"), Position, LinearVel, AngularVel);
+        return FString::Printf(
+            TEXT("Pos: %lf[rad or m] LinearVel: %lf[m/s] AngularVel: %lf[rad/s]"), Position, LinearVel, AngularVel);
     }
 
     bool operator==(const FRRRobotJointValue& Other) const
@@ -490,8 +495,10 @@ USTRUCT(BlueprintType)
 struct RAPYUTASIMULATIONPLUGINS_API FRRRobotLinkInertia
 {
     GENERATED_BODY()
+    //! [kg]
     UPROPERTY(EditAnywhere)
     float Mass = 0.f;
+    //! [cm]
     UPROPERTY(EditAnywhere)
     FVector Location = FVector::ZeroVector;
     UPROPERTY(EditAnywhere)
@@ -545,6 +552,11 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRRobotGeometryInfo
     FRRMaterialProperty MaterialInfo;
 };
 
+/**
+ * @brief Sensor lidar info
+ * @sa [URDF-Sensor](http://wiki.ros.org/urdf/XML/sensor)
+ * @sa [SDF-Sensor](http://sdformat.org/spec?elem=sensor)
+ */
 USTRUCT(BlueprintType)
 struct RAPYUTASIMULATIONPLUGINS_API FRRSensorLidarInfo
 {
@@ -552,33 +564,41 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRSensorLidarInfo
     UPROPERTY(EditAnywhere)
     ERRLidarSensorType LidarType = ERRLidarSensorType::NONE;
 
-    //! Scan (angle in deg)
+    //! The number of simulated lidar rays to generate per complete laser sweep cycle
     UPROPERTY(EditAnywhere)
     int32 NHorSamplesPerScan = 360;
 
-    //! Scan (angle in deg)
+    //! The number of simulated lidar rays to generate per complete laser sweep cycle
     UPROPERTY(EditAnywhere)
     int32 NVerSamplesPerScan = 360;
 
-    //! Scan (angle in deg)
+    //! [deg]
     UPROPERTY(EditAnywhere)
     float HMinAngle = 0.f;
+    //! [deg]
     UPROPERTY(EditAnywhere)
     float HMaxAngle = 0.f;
+    //! Factor to be multiplied by samples to determine the number of range data points returned
     UPROPERTY(EditAnywhere)
     float HResolution = 0.f;
+    //! [deg]
     UPROPERTY(EditAnywhere)
     float VMinAngle = 0.f;
+    //! [deg]
     UPROPERTY(EditAnywhere)
     float VMaxAngle = 0.f;
+    //! Factor to be multiplied by samples to determine the number of range data points returned
     UPROPERTY(EditAnywhere)
     float VResolution = 0.f;
 
     // Range
+    //! [cm] The minimum distance for each lidar ray
     UPROPERTY(EditAnywhere)
     float MinRange = 0.f;
+    //! [cm] The maximum distance for each lidar ray
     UPROPERTY(EditAnywhere)
     float MaxRange = 0.f;
+    //! Linear resolution of each lidar ray
     UPROPERTY(EditAnywhere)
     float RangeResolution = 0.f;
 
@@ -763,21 +783,22 @@ public:
     UPROPERTY(EditAnywhere)
     FString WheelName;
 
-    /** If left undefined then the #bAffectedByEngine value is used, if defined then #bAffectedByEngine is ignored and the
-     * differential setup on the vehicle defines which wheels get power from the engine */
+    //! If left undefined then the #bAffectedByEngine value is used, if defined then #bAffectedByEngine is ignored and the
+    //! differential setup on the vehicle defines which wheels get power from the engine
     UPROPERTY(EditAnywhere)
     EAxleType AxleType = EAxleType::Undefined;
 
-    /**
-     * If BoneName is specified, offset the wheel from the bone's location.
-     * Otherwise this offsets the wheel from the vehicle's origin.
-     */
+    //! If BoneName is specified, offset the wheel from the bone's location.
+    //! Otherwise this offsets the wheel from the vehicle's origin.
+    //! [cm]
     UPROPERTY(EditAnywhere)
     FVector Offset = FVector::ZeroVector;
 
+    //! [cm]
     UPROPERTY(EditAnywhere)
     float WheelRadius = 0.f;
 
+    //! [cm]
     UPROPERTY(EditAnywhere)
     float WheelWidth = 0.f;
 
@@ -836,10 +857,12 @@ public:
     FVector SuspensionForceOffset = FVector::ZeroVector;
 
     //! How far the wheel can go above the resting position
+    //! [cm]
     UPROPERTY(EditAnywhere)
     float SuspensionMaxRaise = 10.f;
 
     //! How far the wheel can drop below the resting position
+    //! [cm]
     UPROPERTY(EditAnywhere)
     float SuspensionMaxDrop = 10.f;
 
@@ -847,17 +870,15 @@ public:
     UPROPERTY(EditAnywhere)
     float SuspensionDampingRatio = 0.5f;
 
-    /** Smooth suspension [0-off, 10-max] - Warning might cause momentary visual inter-penetration of the wheel against
-     * objects/terrain */
+    //! Smooth suspension [0-off, 10-max] - Warning might cause momentary visual inter-penetration of the wheel against
+    //! objects/terrain
     UPROPERTY(EditAnywhere)
     int8 SuspensionSmoothing = 0;
 
-    /**
-     * Amount wheel load effects wheel friction.
-     * At 0 wheel friction is completely independent of the loading on the wheel (This is artificial as it always assumes even
-     * balance between all wheels) At 1 wheel friction is based on the force pressing wheel into the ground. This is more
-     * realistic. Lower value cures lift off over-steer, generally makes vehicle easier to handle under extreme motions.
-     */
+    //! Amount wheel load effects wheel friction.
+    //! At 0 wheel friction is completely independent of the loading on the wheel (This is artificial as it always assumes even
+    //! balance between all wheels) At 1 wheel friction is based on the force pressing wheel into the ground. This is more
+    //! realistic. Lower value cures lift off over-steer, generally makes vehicle easier to handle under extreme motions.
     UPROPERTY(EditAnywhere)
     float WheelLoadRatio = 0.5f;
 
@@ -881,23 +902,23 @@ public:
     UPROPERTY(EditAnywhere)
     ESweepType SweepType = ESweepType::SimpleSweep;
 
+    //! [deg]
     UPROPERTY(EditAnywhere)
     float MaxSteerAngleDeg = 50.f;
 
-    //! max brake torque for this wheel (Nm)
+    //! [Nm]
     UPROPERTY(EditAnywhere)
     float MaxBrakeTorque = 1500.f;
 
-    /**
-     * Max handbrake brake torque for this wheel (Nm). A handbrake should have a stronger brake torque
-     * than the brake. This will be ignored for wheels that are not affected by the handbrake.
-     */
+    // ! Max handbrake brake torque for this wheel (Nm). A handbrake should have a stronger brake torque
+    // ! than the brake. This will be ignored for wheels that are not affected by the handbrake.
+    //! [Nm]
     UPROPERTY(EditAnywhere)
     float MaxHandBrakeTorque = 3000.f;
 
     void PrintSelf() const
     {
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("WheelName: %s Radius %f Width %f"), *WheelName, WheelRadius, WheelWidth);
+        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("WheelName: %s Radius %f[cm] Width %f[cm]"), *WheelName, WheelRadius, WheelWidth);
     }
 };
 
@@ -918,9 +939,11 @@ public:
 };
 
 // [ROBOT MODEL] --
-//
+/**
+ * @brief Core UE struct housing robot model data, wrapped by #FRRRobotModelInfo & #FRRRobotModelTableRow
+ */
 USTRUCT(BlueprintType)
-struct FRRRobotModelData : public FTableRowBase
+struct FRRRobotModelData
 {
     GENERATED_BODY()
 public:
@@ -1471,12 +1494,19 @@ public:
     }
 };    // END FRRRobotModelData
 
+/**
+ * @brief Struct, inheriting from #FTableRowBase, storing entry data for #UDataTable
+ * @sa [Ref](https://docs.unrealengine.com/5.2/en-US/API/Runtime/Engine/Engine/FTableRowBase)
+ */
 USTRUCT(BlueprintType)
 struct RAPYUTASIMULATIONPLUGINS_API FRRRobotModelTableRow : public FTableRowBase
 {
     GENERATED_BODY()
 public:
     FRRRobotModelTableRow(const FRRRobotModelData& InRobotModelData) : Data(InRobotModelData)
+    {
+    }
+    FRRRobotModelTableRow(FRRRobotModelData&& InRobotModelData) : Data(MoveTemp(InRobotModelData))
     {
     }
     FRRRobotModelTableRow()
@@ -1486,6 +1516,9 @@ public:
     FRRRobotModelData Data;
 };
 
+/**
+ * @brief Plain struct wrapping robot model data (#FRRRobotModelData), being thread-safe accessible through TSharedRef if created with TSharedPtr
+ */
 struct RAPYUTASIMULATIONPLUGINS_API FRRRobotModelInfo : public TSharedFromThis<FRRRobotModelInfo, ESPMode::ThreadSafe>
 {
 public:


### PR DESCRIPTION
RRRobotStructs Add `FRRRobotModelData`, used by `FRRRobotModelInfo` (dynamic runtime robot models info as loaded from URDF/SDF) & `FRRRobotModelTableRow` (static BP robot models info as stored in UE data table asset)
`ERRResourceDataType` add `UE_DATA_TABLE,` auto early loading existing data table dynamic assets