### PR TITLE
Asset saving: handle already existing name-sake

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -141,6 +141,11 @@ FString ARRBaseRobot::GetDynamicResourceName(const ERRResourceDataType InDataTyp
     return URRUObjectUtils::ComposeDynamicResourceName(URRGameSingleton::GetAssetNamePrefix(InDataType), *RobotModelName);
 }
 
+FString ARRBaseRobot::GetDynamicResourceAssetPath(const ERRResourceDataType InDataType) const
+{
+    return RRGameSingleton->GetSimResourceInfo(InDataType).Data.FindRef(GetDynamicResourceName(InDataType)).GetAssetPath();
+}
+
 void ARRBaseRobot::PreInitializeComponents()
 {
     if (ROSSpawnParameters)

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRAssetUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRAssetUtils.h
@@ -286,6 +286,28 @@ public:
     }
 
     /**
+     * @brief Check whether an asset has been created at a path
+     * @param InAssetPath Full UE asset path (eg: /Game/Contents/DynamicContents/SK_Obj)
+     * @param bOnDiskAssetOnly
+     * @return bool
+     */
+    static bool DoesAssetExist(const FString& InAssetPath, bool bOnDiskAssetOnly = false)
+    {
+        const auto& assetPackageName = FName(*InAssetPath);
+        return bOnDiskAssetOnly ? GetAssetRegistry().GetAssetPackageDataCopy(assetPackageName).IsSet()
+                                : GetAssetRegistry().HasAssets(assetPackageName);
+    }
+
+    /**
+     * @brief Create a package meant to be saved to asset file on disk
+     * @param InPackageName
+     * @param InPackageFlags
+     * @return UPackage*
+     */
+    static UPackage* CreatePackageForSavingToAsset(const TCHAR* InPackageName,
+                                                   const EPackageFlags InPackageFlags = (PKG_NewlyCreated | PKG_RuntimeGenerated));
+
+    /**
      * @brief Save object in memory to asset file on disk stored by a module
      * @param InObject
      * @param InAssetDataType
@@ -295,16 +317,16 @@ public:
      * @param bInStripEditorOnlyContent
      * @return true if succeeded
      */
-    static bool SaveObjectToAssetInModule(UObject* InObject,
-                                          const ERRResourceDataType InAssetDataType,
-                                          const FString& InAssetUniqueName,
-                                          const TCHAR* InModuleName,
-                                          bool bSaveDuplicatedObject = false,
-                                          bool bInStripEditorOnlyContent = false);
+    static UObject* SaveObjectToAssetInModule(UObject* InObject,
+                                              const ERRResourceDataType InAssetDataType,
+                                              const FString& InAssetUniqueName,
+                                              const TCHAR* InModuleName,
+                                              bool bSaveDuplicatedObject = false,
+                                              bool bInStripEditorOnlyContent = false);
     /**
      * @brief Save object in memory to asset file on disk
      * @param InObject
-     * @param InAssetPath Base package path of the output asset
+     * @param InAssetPath Full UE asset path of the output asset (eg: /Game/Contents/DynamicContents/SK_Obj)
      * @param bSaveDuplicatedObject
      * @param bInStripEditorOnlyContent
      * @return true if succeeded
@@ -312,17 +334,18 @@ public:
      * @sa https://forums.unrealengine.com/t/dynamically-created-primary-assets-not-registering-with-asset-manager/210255
      * @sa https://forums.unrealengine.com/t/how-to-work-with-cooked-content-in-editor/265094
      */
-    static bool SaveObjectToAsset(UObject* InObject,
-                                  const FString& InAssetPath,
-                                  bool bSaveDuplicatedObject = false,
-                                  bool bInStripEditorOnlyContent = false);
+    static UObject* SaveObjectToAsset(UObject* InObject,
+                                      const FString& InAssetPath,
+                                      bool bSaveDuplicatedObject = false,
+                                      bool bInStripEditorOnlyContent = false);
 
     /**
      * @brief Save package to asset file on disk
      * @param InObject
+     * @param bAsyncSave default true to avoid block-waiting on data writing to disk
      * @return true if succeeded
      */
-    static bool SavePackageToAsset(UPackage* InPackage, UObject* InObject);
+    static bool SavePackageToAsset(UPackage* InPackage, UObject* InObject, bool bAsyncSave = true);
 
     /**
      * @brief Find generated UClass from blueprint class name

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRAssetUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRAssetUtils.h
@@ -315,6 +315,8 @@ public:
      * @param InModuleName
      * @param bSaveDuplicatedObject
      * @param bInStripEditorOnlyContent
+     * @param bInAsyncSave default true to avoid block-waiting on data writing to disk
+     * @param bInAlwaysOverwrite default false to avoid liberty of overwriting
      * @return true if succeeded
      */
     static UObject* SaveObjectToAssetInModule(UObject* InObject,
@@ -322,13 +324,17 @@ public:
                                               const FString& InAssetUniqueName,
                                               const TCHAR* InModuleName,
                                               bool bSaveDuplicatedObject = false,
-                                              bool bInStripEditorOnlyContent = false);
+                                              bool bInStripEditorOnlyContent = false,
+                                              bool bInAsyncSave = true,
+                                              bool bInAlwaysOverwrite = false);
     /**
      * @brief Save object in memory to asset file on disk
      * @param InObject
      * @param InAssetPath Full UE asset path of the output asset (eg: /Game/Contents/DynamicContents/SK_Obj)
      * @param bSaveDuplicatedObject
      * @param bInStripEditorOnlyContent
+     * @param bInAsyncSave default true to avoid block-waiting on data writing to disk
+     * @param bInAlwaysOverwrite default false to avoid liberty of overwriting
      * @return true if succeeded
      * @sa https://forums.unrealengine.com/t/calling-upackage-savepackage-causes-fatal-assert-in-staticfindobjectfast/447917
      * @sa https://forums.unrealengine.com/t/dynamically-created-primary-assets-not-registering-with-asset-manager/210255
@@ -337,15 +343,21 @@ public:
     static UObject* SaveObjectToAsset(UObject* InObject,
                                       const FString& InAssetPath,
                                       bool bSaveDuplicatedObject = false,
-                                      bool bInStripEditorOnlyContent = false);
+                                      bool bInStripEditorOnlyContent = false,
+                                      bool bInAsyncSave = true,
+                                      bool bInAlwaysOverwrite = false);
 
     /**
      * @brief Save package to asset file on disk
      * @param InObject
-     * @param bAsyncSave default true to avoid block-waiting on data writing to disk
+     * @param bInAsyncSave default true to avoid block-waiting on data writing to disk
+     * @param bInAlwaysOverwrite default false to avoid liberty of overwriting
      * @return true if succeeded
      */
-    static bool SavePackageToAsset(UPackage* InPackage, UObject* InObject, bool bAsyncSave = true);
+    static bool SavePackageToAsset(UPackage* InPackage,
+                                   UObject* InObject,
+                                   bool bInAsyncSave = true,
+                                   bool bInAlwaysOverwrite = false);
 
     /**
      * @brief Find generated UClass from blueprint class name

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRTypeUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRTypeUtils.h
@@ -18,7 +18,7 @@
 
 /**
  * @brief UE/std type related utils
- * 
+ *
  */
 template<typename T>
 struct TIsBoolean
@@ -38,14 +38,21 @@ struct TIsBoolean<bool>
     };
 };
 
+template<typename T>
+struct TIsCharPointer
+{
+    enum
+    {
+        Value = TAnd<TIsPointer<T>, TIsCharType<typename TRemoveCV<typename TRemovePointer<T>::Type>::Type>>::Value
+    };
+};
+
 UCLASS()
 class RAPYUTASIMULATIONPLUGINS_API URRTypeUtils : public UBlueprintFunctionLibrary
 {
     GENERATED_BODY()
 
 public:
-    // UE-TYPE RELATED UTILS ==
-    //
     // UE-TYPE RELATED UTILS ==
     //
     template<typename TEnum>

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -145,10 +145,18 @@ public:
     }
 
     /**
-     * @brief Get name of a dynamic robot resource (mesh, skeleton, physics asset, etc.)
+     * @brief Get name of an already-stored dynamic robot resource (mesh, skeleton, physics asset, etc.)
      * @param InDataType
+     * @return FString
      */
     FString GetDynamicResourceName(const ERRResourceDataType InDataType) const;
+
+    /**
+     * @brief Get UE asset path of an already-stored dynamic robot resource (mesh, skeleton, physics asset, etc.)
+     * @param InDataType
+     * @return FString
+     */
+    FString GetDynamicResourceAssetPath(const ERRResourceDataType InDataType) const;
 
     //! Robot creation done delegate
     FOnRobotCreationDone OnRobotCreationDone;


### PR DESCRIPTION
`URRAssetUtils`
   * add `CreatePackageForSavingToAsset()`, called by `SaveObjectToAsset()` to allow creation of an independent package, which then could wrap some target objects before being saved to asset
   * `SaveObjectToAsset()` handle in case of already existing same-name asset

`URRBaseRobot` add `GetDynamicResourceAssetPath()`, retuning the saved path of a dynamically loaded resource asset
`URRConversionUtils` add `ToString() & ArrayToString()`