### PR TITLE
adds WITH_EDITOR for GetMetaData to avoid crash when packaged

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
@@ -240,6 +240,12 @@ UObject* URRAssetUtils::SaveObjectToAsset(UObject* InObject,
         *uniquePackageName,
         PKG_NewlyCreated | PKG_RuntimeGenerated | (bInStripEditorOnlyContent ? PKG_FilterEditorOnly : PKG_None));
 
+    if (nullptr == package)
+    {
+        UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("[%s] UNABLE TO CREATE PACKAGE FOR [%s]"), *InAssetPath, *InObject->GetName());
+        return nullptr;
+    }
+  
     // Configure [savedObject]
     UObject* savedObject = nullptr;
     if (bSaveDuplicatedObject)

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
@@ -234,6 +234,7 @@ UObject* URRAssetUtils::SaveObjectToAsset(UObject* InObject,
     uniquePackageName = InAssetPath;
     uniqueAssetName = FPaths::GetBaseFilename(InAssetPath);
 
+#if WITH_EDITOR
     // Create package wrapping [savedObject]
     UPackage* package = CreatePackageForSavingToAsset(
         *uniquePackageName,
@@ -256,6 +257,10 @@ UObject* URRAssetUtils::SaveObjectToAsset(UObject* InObject,
 
     // Save [package] to uasset file on disk
     return SavePackageToAsset(package, savedObject, bInAsyncSave, bInAlwaysOverwrite) ? savedObject : nullptr;
+    
+#else
+    return nullptr;
+#endif
 }
 
 bool URRAssetUtils::SavePackageToAsset(UPackage* InPackage, UObject* InObject, bool bInAsyncSave, bool bInAlwaysOverwrite)

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
@@ -167,11 +167,15 @@ UBlueprint* URRAssetUtils::CreateBlueprintFromActor(AActor* InActor,
 
 UPackage* URRAssetUtils::CreatePackageForSavingToAsset(const TCHAR* InPackageName, const EPackageFlags InPackageFlags)
 {
+#if WITH_EDITOR
     UPackage* package = CreatePackage(InPackageName);
     // NOTE: [GetMetaData()] is required to avoid error "Illegal call to StaticFindObjectFast()" during package saving later
     package->GetMetaData();
     package->SetPackageFlags(InPackageFlags);
     return package;
+#else
+    return nullptr;
+#endif
 }
 
 UObject* URRAssetUtils::SaveObjectToAssetInModule(UObject* InObject,


### PR DESCRIPTION
packaged version was crashing with errors 
```
Signal 11 caught.
Malloc Size=262146 LargeMemoryPoolOffset=262162 
CommonUnixCrashHandler: Signal=11
[2023.06.15-08.44.40:707][ 10]LogCore: === Critical error: ===
Unhandled Exception: SIGSEGV: invalid attempt to write memory at address 0x0000000000000003

[2023.06.15-08.44.40:707][ 10]LogCore: Assertion failed: !FPlatformProperties::RequiresCookedData() [File:./Runtime/CoreUObject/Private/UObject/Package.cpp] [Line: 189] 
MetaData is only allowed in the Editor.
0x0000000006e761e6 sootballs_UE!UPackage::GetMetaData()()
0x000000000458d4bc sootballs_UE!URRAssetUtils::SaveObjectToAsset(...
```
