### PR TITLE
Accomodate Cmdlet

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRActorCommon.cpp
@@ -174,6 +174,22 @@ URRActorCommon* URRActorCommon::GetActorCommon(int8 InSceneInstanceId, UClass* I
 {
     if (!SActorCommonList.Contains(InSceneInstanceId))
     {
+#if WITH_EDITOR
+        // Running as cmdlet -> auto specify Outer & type class
+        if (IsRunningCommandlet())
+        {
+            if (nullptr == InOuter)
+            {
+                InOuter = URRCoreUtils::GetEditorWorld();
+                ensure(InOuter);
+            }
+            if (nullptr == InActorCommonClass)
+            {
+                InActorCommonClass = URRActorCommon::StaticClass();
+            }
+        }
+#endif
+
         // First time fetching should come with valid [InOuter] for the creation
         if (InOuter->IsValidLowLevel() && InActorCommonClass)
         {

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
@@ -104,7 +104,7 @@ UClass* URRAssetUtils::CreateBlueprintClass(UClass* InParentClass,
         return bpGeneratedClass;
     }
 #else
-    UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("UClass runtime creation requires WITH_EDITOR"));
+    UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("UClass runtime creation is Editor-only"));
 #endif
     return nullptr;
 }
@@ -174,6 +174,7 @@ UPackage* URRAssetUtils::CreatePackageForSavingToAsset(const TCHAR* InPackageNam
     package->SetPackageFlags(InPackageFlags);
     return package;
 #else
+    UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("Package creation is Editor-only"));
     return nullptr;
 #endif
 }
@@ -187,6 +188,7 @@ UObject* URRAssetUtils::SaveObjectToAssetInModule(UObject* InObject,
                                                   bool bInAsyncSave,
                                                   bool bInAlwaysOverwrite)
 {
+#if WITH_EDITOR
     return URRAssetUtils::SaveObjectToAsset(
         InObject,
         URRGameSingleton::Get()->GetDynamicAssetPath(InAssetDataType, InAssetUniqueName, InModuleName),
@@ -194,6 +196,10 @@ UObject* URRAssetUtils::SaveObjectToAssetInModule(UObject* InObject,
         bInStripEditorOnlyContent,
         bInAsyncSave,
         bInAlwaysOverwrite);
+#else
+    UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("Editor-only api!"));
+    return nullptr;
+#endif
 }
 
 UObject* URRAssetUtils::SaveObjectToAsset(UObject* InObject,
@@ -203,6 +209,7 @@ UObject* URRAssetUtils::SaveObjectToAsset(UObject* InObject,
                                           bool bInAsyncSave,
                                           bool bInAlwaysOverwrite)
 {
+#if WITH_EDITOR
     // Compose package name
     FString uniquePackageName, uniqueAssetName;
     if (DoesAssetExist(InAssetPath))
@@ -238,7 +245,6 @@ UObject* URRAssetUtils::SaveObjectToAsset(UObject* InObject,
     uniquePackageName = InAssetPath;
     uniqueAssetName = FPaths::GetBaseFilename(InAssetPath);
 
-#if WITH_EDITOR
     // Create package wrapping [savedObject]
     UPackage* package = CreatePackageForSavingToAsset(
         *uniquePackageName,
@@ -249,7 +255,7 @@ UObject* URRAssetUtils::SaveObjectToAsset(UObject* InObject,
         UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("[%s] UNABLE TO CREATE PACKAGE FOR [%s]"), *InAssetPath, *InObject->GetName());
         return nullptr;
     }
-  
+
     // Configure [savedObject]
     UObject* savedObject = nullptr;
     if (bSaveDuplicatedObject)
@@ -267,14 +273,15 @@ UObject* URRAssetUtils::SaveObjectToAsset(UObject* InObject,
 
     // Save [package] to uasset file on disk
     return SavePackageToAsset(package, savedObject, bInAsyncSave, bInAlwaysOverwrite) ? savedObject : nullptr;
-    
 #else
+    UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("Editor-only api!"));
     return nullptr;
 #endif
 }
 
 bool URRAssetUtils::SavePackageToAsset(UPackage* InPackage, UObject* InObject, bool bInAsyncSave, bool bInAlwaysOverwrite)
 {
+#if WITH_EDITOR
     // Mark both dirty
     if (InObject)
     {
@@ -351,4 +358,8 @@ bool URRAssetUtils::SavePackageToAsset(UPackage* InPackage, UObject* InObject, b
             return false;
         }
     }
+#else
+    UE_LOG_WITH_INFO(LogRapyutaCore, Error, TEXT("Editor-only api!"));
+    return false;
+#endif
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
@@ -35,10 +35,8 @@ UClass* URRAssetUtils::CreateBlueprintClass(UClass* InParentClass,
     kismetCompilerModule.GetBlueprintTypesForClass(InParentClass, blueprintClass, blueprintGeneratedClass);
 
     // 2- Create blueprint package for the class asset
-    FString bpPackageName =
-        FString::Printf(TEXT("%s/%s"),
-                        (InBPBasePath.IsEmpty() ? *URRGameSingleton::Get()->ASSETS_RUNTIME_BP_SAVE_BASE_PATH : *InBPBasePath),
-                        *InBlueprintClassName);
+    FString bpPackageName = InBPBasePath.IsEmpty() ? URRGameSingleton::Get()->GetDynamicBPAssetPath(InBlueprintClassName)
+                                                   : InBPBasePath / InBlueprintClassName;
     FString bpAssetName;
     assetToolsModule.Get().CreateUniqueAssetName(bpPackageName, TEXT(""), bpPackageName, bpAssetName);
     UPackage* bpPackage = CreatePackage(*bpPackageName);
@@ -116,8 +114,7 @@ UBlueprint* URRAssetUtils::CreateBlueprintFromActor(AActor* InActor,
 {
 #if WITH_EDITOR
     // 1- Create blueprint package as child class of [InActor]'s GetClass()
-    FString bpPackageName =
-        FString::Printf(TEXT("%s/%s"), *URRGameSingleton::Get()->ASSETS_RUNTIME_BP_SAVE_BASE_PATH, *InBlueprintClassName);
+    FString bpPackageName = URRGameSingleton::Get()->GetDynamicBPAssetPath(InBlueprintClassName);
     FString bpAssetName;
     URRAssetUtils::GetAssetToolsModule().CreateUniqueAssetName(bpPackageName, TEXT(""), bpPackageName, bpAssetName);
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
@@ -233,7 +233,12 @@ bool URRCoreUtils::LoadFullFilePaths(const FString& InFolderPath,
         {
             const FString& fileTypesStr = FString::JoinBy(
                 InFileTypes, TEXT(","), [](const ERRFileType& InFileType) { return URRCoreUtils::GetSimFileExt(InFileType); });
-            UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("NO files of extension [%s] inside [%s]"), *fileTypesStr, *InFolderPath);
+            UE_LOG_WITH_INFO(LogRapyutaCore,
+                             Warning,
+                             TEXT("NO files of extension [%s] %s inside [%s]"),
+                             *fileTypesStr,
+                             bInRecursive ? EMPTY_STR : TEXT("directly"),
+                             *InFolderPath);
         }
     }
     else

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
@@ -205,7 +205,8 @@ void URRCoreUtils::ExecuteSimQuitCommand(const UObject* InContextObject)
 //
 bool URRCoreUtils::LoadFullFilePaths(const FString& InFolderPath,
                                      TArray<FString>& OutFilePaths,
-                                     const TArray<ERRFileType>& InFileTypes)
+                                     const TArray<ERRFileType>& InFileTypes,
+                                     const bool bInRecursive)
 {
     bool bResult = false;
 
@@ -215,8 +216,15 @@ bool URRCoreUtils::LoadFullFilePaths(const FString& InFolderPath,
         for (const auto& fileType : InFileTypes)
         {
             TArray<FString> filePaths;
-            fileManager.FindFilesRecursive(
-                filePaths, *InFolderPath, *FString::Printf(TEXT("*%s"), URRCoreUtils::GetSimFileExt(fileType)), true, false);
+            if (bInRecursive)
+            {
+                fileManager.FindFilesRecursive(
+                    filePaths, *InFolderPath, *FString::Printf(TEXT("*%s"), URRCoreUtils::GetSimFileExt(fileType)), true, false);
+            }
+            else
+            {
+                fileManager.FindFiles(filePaths, *InFolderPath, URRCoreUtils::GetSimFileExt(fileType));
+            }
             OutFilePaths.Append(filePaths);
         }
 
@@ -225,11 +233,7 @@ bool URRCoreUtils::LoadFullFilePaths(const FString& InFolderPath,
         {
             const FString& fileTypesStr = FString::JoinBy(
                 InFileTypes, TEXT(","), [](const ERRFileType& InFileType) { return URRCoreUtils::GetSimFileExt(InFileType); });
-            UE_LOG_WITH_INFO(LogRapyutaCore,
-                             Error,
-                             TEXT("Failed to find any files of extension [%s] inside [%s]"),
-                             *fileTypesStr,
-                             *InFolderPath);
+            UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("NO files of extension [%s] inside [%s]"), *fileTypesStr, *InFolderPath);
         }
     }
     else

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -43,11 +43,13 @@ void URRGameSingleton::PrintSimConfig() const
     for (auto i = static_cast<int8>(ERRResourceDataType::NONE); i < static_cast<int8>(ERRResourceDataType::TOTAL); ++i)
     {
         const ERRResourceDataType dataType = static_cast<ERRResourceDataType>(i);
-        UE_LOG(
-            LogRapyutaCore, Display, TEXT("[%s]'s dynamic-assets paths:"), *URRTypeUtils::GetERRResourceDataTypeAsString(dataType));
-        for (const auto& path : GetDynamicAssetsPathList(dataType))
+        UE_LOG(LogRapyutaCore,
+               Display,
+               TEXT("[%s]'s dynamic-assets base paths:"),
+               *URRTypeUtils::GetERRResourceDataTypeAsString(dataType));
+        for (const auto& basePath : GetDynamicAssetsBasePathList(dataType))
         {
-            UE_LOG(LogRapyutaCore, Display, TEXT("%s"), *path);
+            UE_LOG(LogRapyutaCore, Display, TEXT("%s"), *basePath);
         }
     }
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -30,7 +30,26 @@ URRGameSingleton::~URRGameSingleton()
 
 void URRGameSingleton::PrintSimConfig() const
 {
-    UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("- SIM PROFILING: %d"), BSIM_PROFILING);
+    UE_LOG(LogRapyutaCore, Display, TEXT("RRGameSingleton Configs:"));
+    UE_LOG(LogRapyutaCore, Display, TEXT("- SIM PROFILING: %d"), BSIM_PROFILING);
+    UE_LOG(LogRapyutaCore, Display, TEXT("- ASSETS_RUNTIME_BP_SAVE_BASE_PATH: %s"), *ASSETS_RUNTIME_BP_SAVE_BASE_PATH);
+    UE_LOG(LogRapyutaCore, Display, TEXT("- FOLDER_PATH_ASSET_STATIC_MESHES: %s"), *FOLDER_PATH_ASSET_STATIC_MESHES);
+    UE_LOG(LogRapyutaCore, Display, TEXT("- FOLDER_PATH_ASSET_SKELETAL_MESHES: %s"), *FOLDER_PATH_ASSET_SKELETAL_MESHES);
+    UE_LOG(LogRapyutaCore, Display, TEXT("- FOLDER_PATH_ASSET_SKELETONS: %s"), *FOLDER_PATH_ASSET_SKELETONS);
+    UE_LOG(LogRapyutaCore, Display, TEXT("- FOLDER_PATH_PHYSICS_ASSETS: %s"), *FOLDER_PATH_PHYSICS_ASSETS);
+    UE_LOG(LogRapyutaCore, Display, TEXT("- FOLDER_PATH_ASSET_MATERIALS: %s"), *FOLDER_PATH_ASSET_MATERIALS);
+    UE_LOG(LogRapyutaCore, Display, TEXT("- FOLDER_PATH_ASSET_TEXTURES: %s"), *FOLDER_PATH_ASSET_TEXTURES);
+    UE_LOG(LogRapyutaCore, Display, TEXT("- FOLDER_PATH_ASSET_DATA_TABLES: %s"), *FOLDER_PATH_ASSET_DATA_TABLES);
+    for (auto i = static_cast<int8>(ERRResourceDataType::NONE); i < static_cast<int8>(ERRResourceDataType::TOTAL); ++i)
+    {
+        const ERRResourceDataType dataType = static_cast<ERRResourceDataType>(i);
+        UE_LOG(
+            LogRapyutaCore, Display, TEXT("[%s]'s dynamic-assets paths:"), *URRTypeUtils::GetERRResourceDataTypeAsString(dataType));
+        for (const auto& path : GetDynamicAssetsPathList(dataType))
+        {
+            UE_LOG(LogRapyutaCore, Display, TEXT("%s"), *path);
+        }
+    }
 }
 
 URRGameSingleton* URRGameSingleton::Get()
@@ -62,7 +81,7 @@ URRGameSingleton* URRGameSingleton::Get()
     return singleton;
 }
 
-bool URRGameSingleton::InitializeResources()
+bool URRGameSingleton::InitializeResources(bool bInRequestResourceLoading)
 {
     // Prepare an empty [ResourceMap]
     for (uint8 i = (static_cast<uint8>(ERRResourceDataType::NONE) + 1); i < static_cast<uint8>(ERRResourceDataType::TOTAL); ++i)
@@ -71,36 +90,39 @@ bool URRGameSingleton::InitializeResources()
         ResourceMap.Add(dataType, FRRResourceInfo(dataType));
     }
 
-    // READ ALL SIM DYNAMIC RESOURCES (UASSETS) INFO FROM DESGINATED [~CONTENT] FOLDERS
-    // & REGISTER THEM TO BE ASYNC LOADED INTO [ResourceMap]
-    // [STATIC MESH] --
-    RequestResourcesLoading<ERRResourceDataType::UE_STATIC_MESH>();
+    if (bInRequestResourceLoading)
+    {
+        // READ ALL SIM DYNAMIC RESOURCES (UASSETS) INFO FROM DESGINATED [~CONTENT] FOLDERS
+        // & REGISTER THEM TO BE ASYNC LOADED INTO [ResourceMap]
+        // [STATIC MESH] --
+        RequestResourcesLoading<ERRResourceDataType::UE_STATIC_MESH>();
 
-    // [SKELETAL MESH] --
-    RequestResourcesLoading<ERRResourceDataType::UE_SKELETAL_MESH>();
+        // [SKELETAL MESH] --
+        RequestResourcesLoading<ERRResourceDataType::UE_SKELETAL_MESH>();
 
-    // [SKELETON] --
-    RequestResourcesLoading<ERRResourceDataType::UE_SKELETON>();
+        // [SKELETON] --
+        RequestResourcesLoading<ERRResourceDataType::UE_SKELETON>();
 
-    // [PHYSICS ASSET] --
-    RequestResourcesLoading<ERRResourceDataType::UE_PHYSICS_ASSET>();
+        // [PHYSICS ASSET] --
+        RequestResourcesLoading<ERRResourceDataType::UE_PHYSICS_ASSET>();
 
-    // [MATERIAL] --
-    RequestResourcesLoading<ERRResourceDataType::UE_MATERIAL>();
+        // [MATERIAL] --
+        RequestResourcesLoading<ERRResourceDataType::UE_MATERIAL>();
 
-    // [TEXTURE] --
-    RequestResourcesLoading<ERRResourceDataType::UE_TEXTURE>();
+        // [TEXTURE] --
+        RequestResourcesLoading<ERRResourceDataType::UE_TEXTURE>();
 
-    // [DATATABLE] --
-    RequestResourcesLoading<ERRResourceDataType::UE_DATA_TABLE>();
+        // [DATATABLE] --
+        RequestResourcesLoading<ERRResourceDataType::UE_DATA_TABLE>();
 
-    // [BODY SETUP] --
-    // Body setups are dynamically created in runtime only
-    GetSimResourceInfo(ERRResourceDataType::UE_BODY_SETUP).bHasBeenAllLoaded = true;
+        // [BODY SETUP] --
+        // Body setups are dynamically created in runtime only
+        GetSimResourceInfo(ERRResourceDataType::UE_BODY_SETUP).bHasBeenAllLoaded = true;
 
 #if RAPYUTA_SIM_VERBOSE
-    UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("RESOURCES REGISTERED TO BE LOADED!"));
+        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("RESOURCES REGISTERED TO BE LOADED!"));
 #endif
+    }
     return true;
 }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -90,30 +90,31 @@ bool URRGameSingleton::InitializeResources(bool bInRequestResourceLoading)
         ResourceMap.Add(dataType, FRRResourceInfo(dataType));
     }
 
+    bool bResult = true;
     if (bInRequestResourceLoading)
     {
         // READ ALL SIM DYNAMIC RESOURCES (UASSETS) INFO FROM DESGINATED [~CONTENT] FOLDERS
         // & REGISTER THEM TO BE ASYNC LOADED INTO [ResourceMap]
         // [STATIC MESH] --
-        RequestResourcesLoading<ERRResourceDataType::UE_STATIC_MESH>();
+        bResult &= RequestResourcesLoading<ERRResourceDataType::UE_STATIC_MESH>();
 
         // [SKELETAL MESH] --
-        RequestResourcesLoading<ERRResourceDataType::UE_SKELETAL_MESH>();
+        bResult &= RequestResourcesLoading<ERRResourceDataType::UE_SKELETAL_MESH>();
 
         // [SKELETON] --
-        RequestResourcesLoading<ERRResourceDataType::UE_SKELETON>();
+        bResult &= RequestResourcesLoading<ERRResourceDataType::UE_SKELETON>();
 
         // [PHYSICS ASSET] --
-        RequestResourcesLoading<ERRResourceDataType::UE_PHYSICS_ASSET>();
+        bResult &= RequestResourcesLoading<ERRResourceDataType::UE_PHYSICS_ASSET>();
 
         // [MATERIAL] --
-        RequestResourcesLoading<ERRResourceDataType::UE_MATERIAL>();
+        bResult &= RequestResourcesLoading<ERRResourceDataType::UE_MATERIAL>();
 
         // [TEXTURE] --
-        RequestResourcesLoading<ERRResourceDataType::UE_TEXTURE>();
+        bResult &= RequestResourcesLoading<ERRResourceDataType::UE_TEXTURE>();
 
         // [DATATABLE] --
-        RequestResourcesLoading<ERRResourceDataType::UE_DATA_TABLE>();
+        bResult &= RequestResourcesLoading<ERRResourceDataType::UE_DATA_TABLE>();
 
         // [BODY SETUP] --
         // Body setups are dynamically created in runtime only
@@ -123,7 +124,7 @@ bool URRGameSingleton::InitializeResources(bool bInRequestResourceLoading)
         UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("RESOURCES REGISTERED TO BE LOADED!"));
 #endif
     }
-    return true;
+    return bResult;
 }
 
 void URRGameSingleton::FinalizeResources()

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -126,6 +126,15 @@ bool URRGameSingleton::InitializeResources(bool bInRequestResourceLoading)
         UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("RESOURCES REGISTERED TO BE LOADED!"));
 #endif
     }
+    else
+    {
+        // NOTE: NO dynamic resources required -> considered to have been all loaded
+        for (auto& [_, resourceInfo] : ResourceMap)
+        {
+            resourceInfo.bHasBeenAllLoaded = true;
+        }
+    }
+
     return bResult;
 }
 
@@ -141,18 +150,19 @@ void URRGameSingleton::FinalizeResources()
 
 bool URRGameSingleton::HaveAllResourcesBeenLoaded(bool bIsLogged) const
 {
-    bool bResult = true;
     for (const auto& resourceInfo : ResourceMap)
     {
-        bResult &= resourceInfo.Value.bHasBeenAllLoaded;
-        if (!bResult && bIsLogged)
+        if (false == resourceInfo.Value.bHasBeenAllLoaded)
         {
-            UE_LOG_WITH_INFO(LogRapyutaCore,
-                             Warning,
-                             TEXT("[%s] Resources have not yet been fully loaded!"),
-                             *URRTypeUtils::GetERRResourceDataTypeAsString(resourceInfo.Key));
+            if (bIsLogged)
+            {
+                UE_LOG_WITH_INFO(LogRapyutaCore,
+                                 Warning,
+                                 TEXT("[%s] Resources have not yet been fully loaded!"),
+                                 *URRTypeUtils::GetERRResourceDataTypeAsString(resourceInfo.Key));
+            }
+            return false;
         }
     }
-
-    return bResult;
+    return true;
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
@@ -65,13 +65,15 @@ void URRStaticMeshComponent::SetMesh(UStaticMesh* InStaticMesh)
     if ((ECollisionEnabled::PhysicsOnly == collisionType) || (ECollisionEnabled::QueryAndPhysics == collisionType))
     {
         UBodySetup* bodySetup = InStaticMesh->GetBodySetup();
-        verify(bodySetup);
-        verify(EBodyCollisionResponse::BodyCollision_Enabled == bodySetup->CollisionReponse);
-        if (bUseDefaultSimpleCollision)
+        if (ensure(bodySetup))
         {
-            verify(bodySetup->bCreatedPhysicsMeshes);
-            verify(false == bodySetup->bFailedToCreatePhysicsMeshes);
-            verify(bodySetup->bHasCookedCollisionData);
+            ensure(EBodyCollisionResponse::BodyCollision_Enabled == bodySetup->CollisionReponse);
+            if (bUseDefaultSimpleCollision)
+            {
+                ensure(bodySetup->bCreatedPhysicsMeshes);
+                ensure(false == bodySetup->bFailedToCreatePhysicsMeshes);
+                ensure(bodySetup->bHasCookedCollisionData);
+            }
         }
     }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRUObjectUtils.cpp
@@ -219,7 +219,8 @@ ARRBaseActor* URRUObjectUtils::SpawnSimActor(UWorld* InWorld,
                                              const FString& InEntityModelName,
                                              const FString& InActorName,
                                              const FTransform& InActorTransform,
-                                             const ESpawnActorCollisionHandlingMethod InCollisionHandlingType)
+                                             const ESpawnActorCollisionHandlingMethod InCollisionHandlingType,
+                                             const FRRActorSpawnInfo& InActorSpawnInfo)
 {
     // This is needed for any actor that is spawned after Sim initialization, when its BeginPlay() is invoked later
     ARRBaseActor::SSceneInstanceId = InSceneInstanceId;
@@ -246,7 +247,14 @@ ARRBaseActor* URRUObjectUtils::SpawnSimActor(UWorld* InWorld,
 #endif
 
         // Initializing itself
-        ensure(newActor->Initialize());
+        if (InActorSpawnInfo.IsValid())
+        {
+            ensure(newActor->InitializeWithSpawnInfo(InActorSpawnInfo));
+        }
+        else
+        {
+            ensure(newActor->Initialize());
+        }
     }
     else
     {

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -150,7 +150,7 @@ void ARRBaseRobot::PreInitializeComponents()
 {
     if (ROSSpawnParameters)
     {
-        InitPropertiesFromJSON();
+        ensure(InitPropertiesFromJSON());
         RobotModelName = ROSSpawnParameters->ActorModelName;
         RobotUniqueName = ROSSpawnParameters->ActorName;
     }
@@ -584,61 +584,72 @@ void ARRBaseRobot::Tick(float DeltaSeconds)
     }
 }
 
-void ARRBaseRobot::InitPropertiesFromJSON()
+bool ARRBaseRobot::InitPropertiesFromJSON()
 {
+    // Verify [ROSSpawnParameters], which house JSON
+    if (nullptr == ROSSpawnParameters)
+    {
+        // ELSE: This could only be a BP robot & Editor operations might be being done
+        RR_VERIFY_STATIC_BP_ROBOT(this);
+        return false;
+    }
+    return true;
+
+#if RAPYUTA_SIM_DEBUG
     // Example Implementation of Json parser
     // Please overwrite this function to parse your custom parameters
 
-    // if (nullptr == ROSSpawnParameters)
-    // {
-    //     return;
-    // }
+    if (false == Super::InitPropertiesFromJSON())
+    {
+        return false;
+    }
 
-    // TSharedRef<TJsonReader<TCHAR>> jsonReader = TJsonReaderFactory<TCHAR>::Create(ROSSpawnParameters->ActorJsonConfigs);
-    // TSharedPtr<FJsonObject> jsonObj = MakeShareable(new FJsonObject());
-    // if (!FJsonSerializer::Deserialize(jsonReader, jsonObj) && jsonObj.IsValid())
-    // {
-    //     UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Error, TEXT("Failed to deserialize json to object"));
-    //     return;
-    // }
+    TSharedRef<TJsonReader<TCHAR>> jsonReader = TJsonReaderFactory<TCHAR>::Create(ROSSpawnParameters->ActorJsonConfigs);
+    TSharedPtr<FJsonObject> jsonObj = MakeShareable(new FJsonObject());
+    if (!FJsonSerializer::Deserialize(jsonReader, jsonObj) && jsonObj.IsValid())
+    {
+        UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Error, TEXT("Failed to deserialize json to object"));
+        return false;
+    }
 
-    // // Parse single value
-    // bool bParam = false;
-    // if (URRGeneralUtils::GetJsonField(jsonObj, TEXT("bool_value"), bParam))
-    // {
-    //     UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Log, TEXT("bool value: %d"), bParam);
-    // }
-    // else
-    // {
-    //     UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s [bool_value] not found in json config"));
-    // }
+    // Parse single value
+    bool bParam = false;
+    if (URRGeneralUtils::GetJsonField(jsonObj, TEXT("bool_value"), bParam))
+    {
+        UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Log, TEXT("bool value: %d"), bParam);
+    }
+    else
+    {
+        UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s [bool_value] not found in json config"));
+    }
 
-    // // Parse array
-    // const TArray<TSharedPtr<FJsonValue>>* paramArray;
-    // if (!jsonObj->TryGetArrayField(TEXT("array_value"), paramArray))
-    // {
-    //     return;
-    // }
+    // Parse array
+    const TArray<TSharedPtr<FJsonValue>>* paramArray;
+    if (!jsonObj->TryGetArrayField(TEXT("array_value"), paramArray))
+    {
+        return false;
+    }
 
-    // for (const auto& param : *paramArray)
-    // {
-    //     const TSharedPtr<FJsonObject>* jObj;
-    //     if (!param->TryGetObject(jObj))
-    //     {
-    //         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s Not an object !!"));
-    //         continue;
-    //     }
+    for (const auto& param : *paramArray)
+    {
+        const TSharedPtr<FJsonObject>* jObj;
+        if (!param->TryGetObject(jObj))
+        {
+            UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s Not an object !!"));
+            continue;
+        }
 
-    //     // Parse value in array
-    //     float valueInParam = 0.0;
-    //     if( URRGeneralUtils::GetJsonField(*jObj, TEXT("value_in_array"), valueInParam, 0.0f) )
-    //     {
-    //         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Log, TEXT("value_in_array : %f"), valueInParam);
-    //     }
-    //     else
-    //     {
-    //         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s [value_in_array] not found in json config"));
-    //     }
-
-    // }
+        // Parse value in array
+        float valueInParam = 0.0;
+        if (URRGeneralUtils::GetJsonField(*jObj, TEXT("value_in_array"), valueInParam, 0.0f))
+        {
+            UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Log, TEXT("value_in_array : %f"), valueInParam);
+        }
+        else
+        {
+            UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s [value_in_array] not found in json config"));
+        }
+    }
+    return true;
+#endif
 }

--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -150,7 +150,7 @@ void ARRBaseRobot::PreInitializeComponents()
 {
     if (ROSSpawnParameters)
     {
-        ensure(InitPropertiesFromJSON());
+        InitPropertiesFromJSON();
         RobotModelName = ROSSpawnParameters->ActorModelName;
         RobotUniqueName = ROSSpawnParameters->ActorName;
     }
@@ -586,70 +586,10 @@ void ARRBaseRobot::Tick(float DeltaSeconds)
 
 bool ARRBaseRobot::InitPropertiesFromJSON()
 {
-    // Verify [ROSSpawnParameters], which house JSON
+    // Verify [ROSSpawnParameters], which houses JSON
     if (nullptr == ROSSpawnParameters)
     {
-        // ELSE: This could only be a BP robot & Editor operations might be being done
-        RR_VERIFY_STATIC_BP_ROBOT(this);
         return false;
     }
     return true;
-
-#if RAPYUTA_SIM_DEBUG
-    // Example Implementation of Json parser
-    // Please overwrite this function to parse your custom parameters
-
-    if (false == Super::InitPropertiesFromJSON())
-    {
-        return false;
-    }
-
-    TSharedRef<TJsonReader<TCHAR>> jsonReader = TJsonReaderFactory<TCHAR>::Create(ROSSpawnParameters->ActorJsonConfigs);
-    TSharedPtr<FJsonObject> jsonObj = MakeShareable(new FJsonObject());
-    if (!FJsonSerializer::Deserialize(jsonReader, jsonObj) && jsonObj.IsValid())
-    {
-        UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Error, TEXT("Failed to deserialize json to object"));
-        return false;
-    }
-
-    // Parse single value
-    bool bParam = false;
-    if (URRGeneralUtils::GetJsonField(jsonObj, TEXT("bool_value"), bParam))
-    {
-        UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Log, TEXT("bool value: %d"), bParam);
-    }
-    else
-    {
-        UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s [bool_value] not found in json config"));
-    }
-
-    // Parse array
-    const TArray<TSharedPtr<FJsonValue>>* paramArray;
-    if (!jsonObj->TryGetArrayField(TEXT("array_value"), paramArray))
-    {
-        return false;
-    }
-
-    for (const auto& param : *paramArray)
-    {
-        const TSharedPtr<FJsonObject>* jObj;
-        if (!param->TryGetObject(jObj))
-        {
-            UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s Not an object !!"));
-            continue;
-        }
-
-        // Parse value in array
-        float valueInParam = 0.0;
-        if (URRGeneralUtils::GetJsonField(*jObj, TEXT("value_in_array"), valueInParam, 0.0f))
-        {
-            UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Log, TEXT("value_in_array : %f"), valueInParam);
-        }
-        else
-        {
-            UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s [value_in_array] not found in json config"));
-        }
-    }
-    return true;
-#endif
 }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRAssetUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRAssetUtils.h
@@ -55,6 +55,18 @@ public:
     }
 #endif
 
+    /**
+     * @brief Get full asset file path on disk of an UE asset
+     * @param InAssetPath UE asset path
+     * @param OutAssetFilePath Output asset file path on disk (local path)
+     * @return true if convertible
+     */
+    static bool GetAssetFilePathOnDisk(const FString& InAssetPath, FString& OutAssetFilePath)
+    {
+        return FPackageName::TryConvertLongPackageNameToFilename(
+            InAssetPath, OutAssetFilePath, FPackageName::GetAssetPackageExtension());
+    }
+
     static bool IsAssetPackageValid(const FAssetData& InAssetData, bool bIsLogged = false)
     {
         // Package's availability

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
@@ -114,7 +114,7 @@ public:
 public:
     /**
      * @brief ACTOR INTIALIZING GENERAL INFO (Unique name, mesh list, material list, etc.)
-     *
+     * NOTE: This allows child actor to create custom ActorSpawnInfo of its own
      * @tparam TActorSpawnInfo
      * @param InActorInfo
      * @return true
@@ -135,7 +135,7 @@ public:
      * Currently, ARRROS2GameMode & ARRGameMode are separate ones.
      * & Maps of ARRROS2GameMode do NOT YET have actors invoking this method.
      * It is up to the Child class, [Initialize()] could be run inside [BeginPlay()] or some place else in advance!
-     *
+     * ALSO, DUE TO BEING VIRTUAL, CANNOT BE MERGED WITH [InitializeWithSpawnInfo()]
      * @return true
      * @return false
      */

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
@@ -113,6 +113,23 @@ public:
 
 public:
     /**
+     * @brief ACTOR INTIALIZING GENERAL INFO (Unique name, mesh list, material list, etc.)
+     *
+     * @tparam TActorSpawnInfo
+     * @param InActorInfo
+     * @return true
+     * @return false
+     */
+    template<typename TActorSpawnInfo>
+    bool InitializeWithSpawnInfo(const TActorSpawnInfo& InActorInfo)
+    {
+        ActorInfo = MakeShared<TActorSpawnInfo>(InActorInfo);
+
+        // ACTOR INTIALIZING GENERAL INFO (Unique name, mesh list, material list, etc.)
+        return Initialize();
+    }
+
+    /**
      * @brief Set #GameMode #GameState #GameSingleton #PlayerController
      * (NOTE) This method, if being called, could only go with a RRGameMode-inheriting game mode setup!
      * Currently, ARRROS2GameMode & ARRGameMode are separate ones.

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRConversionUtils.h
@@ -267,6 +267,10 @@ public:
         {
             return InValue.ToString();
         }
+        else if constexpr (TIsSame<T, FString>::Value)
+        {
+            return InValue;
+        }
         else
         {
             UE_LOG_WITH_INFO(LogTemp, Error, TEXT("[%s] is not yet supported"), TNameOf<T>::GetName());

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
@@ -198,6 +198,13 @@ public:
 // SIM COMMAND LINE EXECUTION --
 #define CCMDLINE_ARG_FORMAT (TEXT("%s="))
     static constexpr const TCHAR* CCMDLINE_ARG_INT_PHYSX_DISPATCHER_NUM = TEXT("physxDispatcher");
+
+    template<typename TCmdlet>
+    static bool IsRunningSimCommandlet()
+    {
+        return IsRunningCommandlet() && GetRunningCommandletClass()->IsChildOf<TCmdlet>();
+    }
+
     static void ExecuteConsoleCommand(const UObject* InContextObject, const FString& InCommandText)
     {
         if (IsRunningCommandlet())

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -81,12 +81,10 @@ public:
 
     // SIM RESOURCES ==
     //
-
     /**
      * @brief Read all sim dynamic resouces(Uassets) info from designated folders
      * @param bInRequestResourceLoading
-     * @return true
-     * @return false
+     * @return true if inited successfully
      */
     bool InitializeResources(bool bInRequestResourceLoading = true);
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -84,11 +84,11 @@ public:
 
     /**
      * @brief Read all sim dynamic resouces(Uassets) info from designated folders
-     *
+     * @param bInRequestResourceLoading
      * @return true
      * @return false
      */
-    bool InitializeResources();
+    bool InitializeResources(bool bInRequestResourceLoading = true);
 
     /**
      * @brief Finalize #ResourceMap by calling #FRRResourceInfo::Finalize

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRMeshActor.h
@@ -36,42 +36,25 @@ public:
 
 public:
     /**
-     * @brief ACTOR INTIALIZING GENERAL INFO (Unique name, mesh list, material list, etc.)
-     * 
-     * @tparam TActorSpawnInfo 
-     * @param InActorInfo 
-     * @return true 
-     * @return false 
-     */
-    template<typename TActorSpawnInfo>
-    bool InitializeWithSpawnInfo(const TActorSpawnInfo& InActorInfo)
-    {
-        ActorInfo = MakeShared<TActorSpawnInfo>(InActorInfo);
-
-        // ACTOR INTIALIZING GENERAL INFO (Unique name, mesh list, material list, etc.)
-        return Initialize();
-    }
-
-    /**
-     * @brief Initialize MeshActor by 1)Create child mesh components, 2)#SetCustomDepthEnabled, 3)Set mobility. 
-     * 
-     * @return true 
-     * @return false 
+     * @brief Initialize MeshActor by 1)Create child mesh components, 2)#SetCustomDepthEnabled, 3)Set mobility.
+     *
+     * @return true
+     * @return false
      */
     virtual bool Initialize() override;
 
     /**
      * @brief Checm #MeshCompList and #BaseMeshComp
-     * 
-     * @param bIsLogged 
-     * @return true 
-     * @return false 
+     *
+     * @param bIsLogged
+     * @return true
+     * @return false
      */
     virtual bool HasInitialized(bool bIsLogged = false) const override;
 
     /**
      * @brief Reset #MeshCompList
-     * 
+     *
      */
     virtual void Reset() override;
     void DrawTransform();
@@ -104,8 +87,8 @@ public:
 
     /**
      * @brief Declare mesh actor full creation with all meshes created
-     * 
-     * @param bInCreationResult 
+     *
+     * @param bInCreationResult
      */
     virtual void DeclareFullCreation(bool bInCreationResult);
 
@@ -228,28 +211,28 @@ public:
 
     /**
      * @brief Enable/Disable Custom Depth rendering pass
-     * @param bIsCustomDepthEnabled 
+     * @param bIsCustomDepthEnabled
      */
     void SetCustomDepthEnabled(bool bIsCustomDepthEnabled);
-    
+
     /**
      * @brief Set Custom Depth Stencil value uniformly for all child mesh comps
-      * 
-      * @param InCustomDepthStencilValue 
+      *
+      * @param InCustomDepthStencilValue
       */
     void SetCustomDepthStencilValue(int32 InCustomDepthStencilValue);
 
     /**
      * @brief Whether Custom depth rendering is enabled
-      * 
-      * @return true 
-      * @return false 
+      *
+      * @return true
+      * @return false
       */
     bool IsCustomDepthEnabled() const;
 
     /**
      * @brief Get mesh comps' custom depth stencil values
-      * @return TArray<int32> 
+      * @return TArray<int32>
       */
     TArray<int32> GetCustomDepthStencilValueList() const;
 
@@ -258,8 +241,8 @@ public:
 
     /**
      * @brief Activate/Deactivate mesh actor
-      * 
-      * @param bInIsActivated 
+      *
+      * @param bInIsActivated
       */
     FORCEINLINE virtual void SetActivated(bool bInIsActivated)
     {

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
@@ -11,6 +11,9 @@
 #include "PhysicsEngine/BodySetup.h"
 #include "UObject/Object.h"
 
+// rclUE
+#include "logUtilities.h"
+
 // RapyutaSim
 #include "RapyutaSimulationPlugins.h"
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
@@ -11,9 +11,6 @@
 #include "PhysicsEngine/BodySetup.h"
 #include "UObject/Object.h"
 
-// rclUE
-#include "logUtilities.h"
-
 // RapyutaSim
 #include "RapyutaSimulationPlugins.h"
 
@@ -181,6 +178,8 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRResourceInfo
 USTRUCT(BlueprintType)
 struct RAPYUTASIMULATIONPLUGINS_API FRRMaterialProperty
 {
+    GENERATED_BODY()
+
     // These property names are defined in master material by the artist
     static constexpr const TCHAR* PROP_NAME_ALBEDO = TEXT("AlbedoTexture");
     static constexpr const TCHAR* PROP_NAME_ORM = TEXT("MergeMapInput");
@@ -189,7 +188,6 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRMaterialProperty
     static constexpr const TCHAR* PROP_NAME_COLOR_ALBEDO = TEXT("ColorAlbedo");
     static constexpr const TCHAR* PROP_NAME_EMISSIVE_STRENGTH = TEXT("EmissiveStrength");
 
-    GENERATED_BODY()
     UPROPERTY(VisibleAnywhere)
     FString Name;
     UPROPERTY(VisibleAnywhere)
@@ -207,17 +205,16 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRMaterialProperty
 
     void PrintSelf() const
     {
-        UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("Material: %s"), *Name);
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("- Color: %s"), *Color.ToString());
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("- AlbedoTextureNameList: %s"), *FString::Join(AlbedoTextureNameList, TEXT(",")));
-        UE_LOG_WITH_INFO(
-            LogTemp,
-            Display,
-            TEXT("- AlbedoColorList: %s"),
-            *FString::JoinBy(AlbedoColorList, TEXT(","), [](const FLinearColor& InColor) { return InColor.ToString(); }));
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("- MaskTextureName: %s"), *MaskTextureName);
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("- ORMTextureName: %s"), *ORMTextureName);
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("- NormalTextureName: %s"), *NormalTextureName);
+        UE_LOG(LogTemp, Warning, TEXT("Material: %s"), *Name);
+        UE_LOG(LogTemp, Display, TEXT("- Color: %s"), *Color.ToString());
+        UE_LOG(LogTemp, Display, TEXT("- AlbedoTextureNameList: %s"), *FString::Join(AlbedoTextureNameList, TEXT(",")));
+        UE_LOG(LogTemp,
+               Display,
+               TEXT("- AlbedoColorList: %s"),
+               *FString::JoinBy(AlbedoColorList, TEXT(","), [](const FLinearColor& InColor) { return InColor.ToString(); }));
+        UE_LOG(LogTemp, Display, TEXT("- MaskTextureName: %s"), *MaskTextureName);
+        UE_LOG(LogTemp, Display, TEXT("- ORMTextureName: %s"), *ORMTextureName);
+        UE_LOG(LogTemp, Display, TEXT("- NormalTextureName: %s"), *NormalTextureName);
     }
 
     bool HasTexture(const FString& InTextureName)

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRProceduralMeshComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRProceduralMeshComponent.h
@@ -43,7 +43,8 @@ public:
 
     FString GetBodySetupModelName() const
     {
-        return URRUObjectUtils::ComposeDynamicResourceName(TEXT("BS"), MeshUniqueName);
+        return URRUObjectUtils::ComposeDynamicResourceName(URRGameSingleton::GetAssetNamePrefix(ERRResourceDataType::UE_BODY_SETUP),
+                                                           MeshUniqueName);
     }
 
     UPROPERTY()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRStaticMeshComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRStaticMeshComponent.h
@@ -97,7 +97,7 @@ public:
     UPROPERTY()
     bool bIsStationary = false;
 
-    //! Whether static mesh is built with simple collision, should be configured in ARRMeshActor::Initialize()
+    //! Whether static mesh is built with simple collision, also configurable in ARRMeshActor::Initialize()
     UPROPERTY()
     bool bUseDefaultSimpleCollision = true;
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRUObjectUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRUObjectUtils.h
@@ -569,7 +569,8 @@ public:
         const FString& InEntityModelName,
         const FString& InActorName = EMPTY_STR,
         const FTransform& InActorTransform = FTransform::Identity,
-        const ESpawnActorCollisionHandlingMethod InCollisionHandlingType = ESpawnActorCollisionHandlingMethod::AlwaysSpawn);
+        const ESpawnActorCollisionHandlingMethod InCollisionHandlingType = ESpawnActorCollisionHandlingMethod::AlwaysSpawn,
+        const FRRActorSpawnInfo& InActorSpawnInfo = FRRActorSpawnInfo());
 
     FORCEINLINE static FVector GetRelativeLocFrom(const AActor* InActor, const AActor* InBaseActor)
     {

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -484,9 +484,10 @@ public:
      * @brief Parse Json parameters in #ROSSpawnParameters
      * This function is called in #PreInitializeComponents
      * Please overwrite this function to parse your custom parameters
+     * @return true/false
     */
     UFUNCTION(BlueprintCallable)
-    virtual void InitPropertiesFromJSON();
+    virtual bool InitPropertiesFromJSON();
 
     // UI WIDGET --
     UPROPERTY()

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -484,6 +484,62 @@ public:
      * @brief Parse Json parameters in #ROSSpawnParameters
      * This function is called in #PreInitializeComponents
      * Please overwrite this function to parse your custom parameters
+     *
+     * \code{Example Implementation of Json parser:}
+     * if (false == Super::InitPropertiesFromJSON())
+     * {
+     *     return false;
+     * }
+
+     * TSharedRef<TJsonReader<TCHAR>> jsonReader = TJsonReaderFactory<TCHAR>::Create(ROSSpawnParameters->ActorJsonConfigs);
+     * TSharedPtr<FJsonObject> jsonObj = MakeShareable(new FJsonObject());
+     * if (!FJsonSerializer::Deserialize(jsonReader, jsonObj) && jsonObj.IsValid())
+     * {
+     *     UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Error, TEXT("Failed to deserialize json to object"));
+     *     return false;
+     * }
+
+     * // Parse single value
+     * bool bParam = false;
+     * if (URRGeneralUtils::GetJsonField(jsonObj, TEXT("bool_value"), bParam))
+     * {
+     *     UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Log, TEXT("bool value: %d"), bParam);
+     * }
+     * else
+     * {
+     *     UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s [bool_value] not found in json config"));
+     * }
+
+     * // Parse array
+     * const TArray<TSharedPtr<FJsonValue>>* paramArray;
+     * if (!jsonObj->TryGetArrayField(TEXT("array_value"), paramArray))
+     * {
+     *     return false;
+     * }
+
+     * for (const auto& param : *paramArray)
+     * {
+     *     const TSharedPtr<FJsonObject>* jObj;
+     *     if (!param->TryGetObject(jObj))
+     *     {
+     *         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s Not an object !!"));
+     *         continue;
+     *     }
+
+     *     // Parse value in array
+     *     float valueInParam = 0.0;
+     *     if (URRGeneralUtils::GetJsonField(*jObj, TEXT("value_in_array"), valueInParam, 0.0f))
+     *     {
+     *         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Log, TEXT("value_in_array : %f"), valueInParam);
+     *     }
+     *     else
+     *     {
+     *         UE_LOG_WITH_INFO_NAMED(LogRapyutaCore, Warning, TEXT("%s [value_in_array] not found in json config"));
+     *     }
+     * }
+     * return true;
+     * \endcode
+     *
      * @return true/false
     */
     UFUNCTION(BlueprintCallable)

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
@@ -1119,7 +1119,55 @@ public:
                                 { return (InWheelProp.WheelName == InLinkName); });
     }
 
-    const FRRRobotLinkProperty FindLinkProp(int8 InLinkIndex) const
+    FRRRobotLinkProperty GetBaseLinkProp() const
+    {
+        for (const auto& linkProp : LinkPropList)
+        {
+            if (linkProp.Name == BaseLinkName)
+            {
+                return linkProp;
+            }
+        }
+        return FRRRobotLinkProperty();
+    }
+
+    FRRRobotLinkProperty GetLinkProp(const FString& InLinkName) const
+    {
+        for (const auto& linkProp : LinkPropList)
+        {
+            if (linkProp.Name == InLinkName)
+            {
+                return linkProp;
+            }
+        }
+        return FRRRobotLinkProperty();
+    }
+
+    FRRRobotJointProperty GetJointProp(const FString& InJointName) const
+    {
+        for (const auto& jointProp : JointPropList)
+        {
+            if (jointProp.Name == InJointName)
+            {
+                return jointProp;
+            }
+        }
+        return FRRRobotJointProperty();
+    }
+
+    FRRRobotJointProperty GetJointPropFromChildLinkName(const FString& InChildLinkName) const
+    {
+        for (const auto& jointProp : JointPropList)
+        {
+            if (jointProp.ChildLinkName == InChildLinkName)
+            {
+                return jointProp;
+            }
+        }
+        return FRRRobotJointProperty();
+    }
+
+    FRRRobotLinkProperty FindLinkProp(int8 InLinkIndex) const
     {
         for (const auto& linkProp : LinkPropList)
         {
@@ -1128,14 +1176,12 @@ public:
                 return linkProp;
             }
         }
-
         return FRRRobotLinkProperty();
     }
 
-    const FRRRobotJointProperty FindJointPropByLinkIndex(int8 InLinkIndex) const
+    FRRRobotJointProperty FindJointPropByLinkIndex(int8 InLinkIndex) const
     {
         const FRRRobotLinkProperty linkProp = FindLinkProp(InLinkIndex);
-
         for (const auto& jointProp : JointPropList)
         {
             if (linkProp.Name == jointProp.ChildLinkName)
@@ -1143,7 +1189,6 @@ public:
                 return jointProp;
             }
         }
-
         return FRRRobotJointProperty();
     }
 
@@ -1612,6 +1657,26 @@ public:
     FORCEINLINE void RemoveLinkJointProp(const FString& InLinkName)
     {
         Data.RemoveLinkJointProp(InLinkName);
+    }
+
+    FORCEINLINE FRRRobotLinkProperty GetBaseLinkProp() const
+    {
+        return Data.GetBaseLinkProp();
+    }
+
+    FORCEINLINE FRRRobotLinkProperty GetLinkProp(const FString& InLinkName) const
+    {
+        return Data.GetLinkProp(InLinkName);
+    }
+
+    FORCEINLINE FRRRobotJointProperty GetJointProp(const FString& InJointName) const
+    {
+        return Data.GetJointProp(InJointName);
+    }
+
+    FORCEINLINE FRRRobotJointProperty GetJointPropFromChildLinkName(const FString& InChildLinkName) const
+    {
+        return Data.GetJointPropFromChildLinkName(InChildLinkName);
     }
 
     FORCEINLINE const FRRRobotLinkProperty FindLinkProp(int8 InLinkIndex) const

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
@@ -1083,6 +1083,10 @@ public:
         }
     }
 
+    /**
+     * @brief Remove all link properties of InLinkName and its corresponding joint properties having their #ParentLinkName as InLinkName
+     * @param InLinkName
+     */
     void RemoveLinkJointProp(const FString& InLinkName)
     {
         // 1- Rem joint prop having [ParentLinkName] as [InLinkName]
@@ -1119,6 +1123,10 @@ public:
                                 { return (InWheelProp.WheelName == InLinkName); });
     }
 
+    /**
+     * @brief Get the property of base link of which the name is denoted by #BaseLinkName
+     * @return FRRRobotLinkProperty
+     */
     FRRRobotLinkProperty GetBaseLinkProp() const
     {
         for (const auto& linkProp : LinkPropList)
@@ -1131,6 +1139,11 @@ public:
         return FRRRobotLinkProperty();
     }
 
+    /**
+     * @brief Get the property of a link by name read from URDF/SDF or CAD like FBX/COLLADA
+     * @param InLinkName
+     * @return FRRRobotLinkProperty
+     */
     FRRRobotLinkProperty GetLinkProp(const FString& InLinkName) const
     {
         for (const auto& linkProp : LinkPropList)
@@ -1143,6 +1156,11 @@ public:
         return FRRRobotLinkProperty();
     }
 
+    /**
+     * @brief Get the property of a joint by name read from URDF/SDF or CAD like FBX/COLLADA
+     * @param InJointName
+     * @return FRRRobotJointProperty
+     */
     FRRRobotJointProperty GetJointProp(const FString& InJointName) const
     {
         for (const auto& jointProp : JointPropList)
@@ -1155,6 +1173,11 @@ public:
         return FRRRobotJointProperty();
     }
 
+    /**
+     * @brief Get the property of the first joint having its child link name as InChildLinkName
+     * @param InChildLinkName
+     * @return FRRRobotJointProperty
+     */
     FRRRobotJointProperty GetJointPropFromChildLinkName(const FString& InChildLinkName) const
     {
         for (const auto& jointProp : JointPropList)
@@ -1167,6 +1190,12 @@ public:
         return FRRRobotJointProperty();
     }
 
+    /**
+     * @brief Get the property of a link by its LinkIndex
+     * NOTE: LinkIndex is assigned indendently from its index in #LinkPropList as building robot skeleton structure
+     * @param InLinkIndex
+     * @return FRRRobotLinkProperty
+     */
     FRRRobotLinkProperty FindLinkProp(int8 InLinkIndex) const
     {
         for (const auto& linkProp : LinkPropList)
@@ -1179,6 +1208,12 @@ public:
         return FRRRobotLinkProperty();
     }
 
+    /**
+     * @brief Get the property of a joint of which the child link name matchs the link property fetched by its LinkIndex
+     * NOTE: LinkIndex is assigned indendently from its index in #LinkPropList as building robot skeleton structure
+     * @param InLinkIndex
+     * @return FRRRobotJointProperty
+     */
     FRRRobotJointProperty FindJointPropByLinkIndex(int8 InLinkIndex) const
     {
         const FRRRobotLinkProperty linkProp = FindLinkProp(InLinkIndex);
@@ -1192,12 +1227,24 @@ public:
         return FRRRobotJointProperty();
     }
 
+    /**
+     * @brief Get visual offset transform of a link by its LinkIndex
+     * NOTE: LinkIndex is assigned indendently from its index in #LinkPropList as building robot skeleton structure
+     * @param InLinkIndex
+     * @return FTransform
+     */
     FTransform GetLinkVisualOffset(int8 InLinkIndex) const
     {
         const FRRRobotLinkProperty& linkProp = FindLinkProp(InLinkIndex);
         return linkProp.GetVisualOffset();
     }
 
+    /**
+     * @brief Get the absolute transform of a link (in owner robot's frame) by its LinkIndex
+     * NOTE: LinkIndex is assigned indendently from its index in #LinkPropList as building robot skeleton structure
+     * @param InLinkIndex
+     * @return FTransform
+     */
     FTransform GetLinkAbsoluteTransform(int8 InLinkIndex) const
     {
         int8 linkIndexCurrent = InLinkIndex;
@@ -1227,6 +1274,12 @@ public:
         return resultTransform;
     }
 
+    /**
+     * @brief Get the relative transform of a link to its parent by its LinkIndex
+     * NOTE: LinkIndex is assigned indendently from its index in #LinkPropList as building robot skeleton structure
+     * @param InLinkIndex
+     * @return FTransform
+     */
     FTransform GetLinkRelativeTransform(int8 InLinkIndex) const
     {
         const FRRRobotJointProperty jointProp = FindJointPropByLinkIndex(InLinkIndex);
@@ -1249,6 +1302,12 @@ public:
         }
     }
 
+    /**
+     * @brief Get the relative transform of a link to base link its LinkIndex
+     * NOTE: LinkIndex is assigned indendently from its index in #LinkPropList as building robot skeleton structure
+     * @param InLinkIndex
+     * @return FTransform
+     */
     FTransform GetLinkRelTransformToBase(int8 InLinkIndex) const
     {
         if (InLinkIndex <= 0)
@@ -1266,6 +1325,12 @@ public:
         return FTransform::Identity;
     }
 
+    /**
+     * @brief Get the visual offset transform of a link to base link its LinkIndex
+     * NOTE: LinkIndex is assigned indendently from its index in #LinkPropList as building robot skeleton structure
+     * @param InLinkIndex
+     * @return FTransform
+     */
     FTransform GetLinkVisualOffsetToBase(int8 InLinkIndex) const
     {
         int8 linkIndexCurrent = InLinkIndex;
@@ -1288,6 +1353,9 @@ public:
         return resultTransform;
     }
 
+    /**
+     * @brief Get model visual info
+     */
     FRRRobotGeometryInfo GetVisualInfo() const
     {
         return ((LinkPropList.Num() > 0) && (LinkPropList[0].VisualList.Num() > 0)) ? LinkPropList[0].VisualList[0]

--- a/Source/RapyutaSimulationPlugins/RapyutaSimulationPlugins.Build.cs
+++ b/Source/RapyutaSimulationPlugins/RapyutaSimulationPlugins.Build.cs
@@ -59,7 +59,6 @@ public class RapyutaSimulationPlugins : ModuleRules
                 new string[]
                 {
                     "UnrealEd",
-                    "EditorScriptingUtilities",
                     "AssetTools",
                     "PhysicsUtilities"
                 }


### PR DESCRIPTION
* `URRCoreUtils` add `IsRunningSimCommandlet<T>()` + `GetEditorWorld()`, used as running in cmdlet that does not have a default world
   * `ExecuteConsoleCommand() + GetActorCommon()` add treatment as running in cmdlet
* URRGameSingleton print configs, showing dynamic assets paths
   * add `GetDynamicBPAssetPath()`
   * `InitResources()` add `bInitRequestResourceLoading` dft true, allowing users to init the resource map only without having always to early load assets if not using
* RRRobotStructs add link/joint prop fetch apis
* Make sure Asset saving is Editor-only
* `URRAssetUtils add` GetAssetFilePathOnDisk()
* `ARRBaseRobot::InitPropertiesFromJSON()` return bool 