### PR TITLE
ERRRobotDescriptionType add SINGLE_CAD

### DIFF
--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -29,6 +29,7 @@
 
 #define RAPYUTA_SIM_VERBOSE (0)    // todo make this CVar
 
+//! NOTES: These 2 DEBUG directives are used mainly for ref code annnotation, thus must NEVER be turned on here globally!
 #define RAPYUTA_SIM_DEBUG (0)
 #define RAPYUTA_SIM_VISUAL_DEBUG (0)
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRBaseActor.h
@@ -14,6 +14,7 @@
 
 // RapyutaSimulationPlugins
 #include "Core/RRActorCommon.h"
+#include "Robots/RRRobotStructs.h"
 
 #include "RRBaseActor.generated.h"
 

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -272,7 +272,7 @@ public:
 
     //! Robot Model Name (loaded from URDF/SDF)
     UPROPERTY(VisibleAnyWhere, BlueprintReadOnly, meta = (ExposeOnSpawn = "true"), Replicated)
-    FString RobotModelName;
+    FString& RobotModelName = EntityModelName;
 
     /**
      * @brief Get robot model name

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
@@ -30,9 +30,11 @@ UENUM()
 enum class ERRRobotDescriptionType : uint8
 {
     NONE,
-    URDF,
-    SDF,
-    UASSET,
+    URDF,             //! [URDF](https://wiki.ros.org/urdf)
+    SDF,              //! [SDF](http://sdformat.org)
+    UE_DATA_TABLE,    //! [UDataTable](https://docs.unrealengine.com/5.2/en-US/API/Runtime/Engine/Engine/UDataTable)
+    SINGLE_CAD,       //! Raw single CAD (FBX, COLLADA, etc.)
+    TOTAL
 };
 
 /**
@@ -223,6 +225,13 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRRobotJointProperty
 {
     GENERATED_BODY()
 public:
+    FRRRobotJointProperty()
+    {
+    }
+    FRRRobotJointProperty(FString InName) : Name(MoveTemp(InName))
+    {
+    }
+
     UPROPERTY(EditAnywhere)
     FString Name;
 
@@ -630,6 +639,12 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRRobotLinkProperty
 {
     GENERATED_BODY()
 public:
+    FRRRobotLinkProperty()
+    {
+    }
+    FRRRobotLinkProperty(FString InName) : Name(MoveTemp(InName))
+    {
+    }
     UPROPERTY(EditAnywhere)
     FString Name;
 
@@ -773,10 +788,7 @@ public:
     FRRRobotWheelProperty()
     {
     }
-    FRRRobotWheelProperty(const FString& InWheelName) : WheelName(InWheelName)
-    {
-    }
-    FRRRobotWheelProperty(FString&& InWheelName) : WheelName(MoveTemp(InWheelName))
+    FRRRobotWheelProperty(FString InWheelName) : WheelName(MoveTemp(InWheelName))
     {
     }
 
@@ -910,8 +922,8 @@ public:
     UPROPERTY(EditAnywhere)
     float MaxBrakeTorque = 1500.f;
 
-    // ! Max handbrake brake torque for this wheel (Nm). A handbrake should have a stronger brake torque
-    // ! than the brake. This will be ignored for wheels that are not affected by the handbrake.
+    //! Max handbrake brake torque for this wheel (Nm). A handbrake should have a stronger brake torque
+    //! than the brake. This will be ignored for wheels that are not affected by the handbrake.
     //! [Nm]
     UPROPERTY(EditAnywhere)
     float MaxHandBrakeTorque = 3000.f;
@@ -950,6 +962,9 @@ public:
     FRRRobotModelData(const TArray<FString>& InModelNameList) : ModelNameList(InModelNameList)
     {
     }
+    FRRRobotModelData(TArray<FString>&& InModelNameList) : ModelNameList(MoveTemp(InModelNameList))
+    {
+    }
     FRRRobotModelData()
     {
     }
@@ -965,11 +980,14 @@ public:
     {
         return (ERRRobotDescriptionType::SDF == ModelDescType);
     }
-    bool IsUAsset() const
+    bool IsUEDataTable() const
     {
-        return (ERRRobotDescriptionType::UASSET == ModelDescType);
+        return (ERRRobotDescriptionType::UE_DATA_TABLE == ModelDescType);
     }
-
+    bool IsSingleCAD() const
+    {
+        return (ERRRobotDescriptionType::SINGLE_CAD == ModelDescType);
+    }
     UPROPERTY(EditAnywhere)
     FString WorldName;
     UPROPERTY()
@@ -1445,7 +1463,7 @@ public:
             }
             return false;
         }
-        else if (WorldName.IsEmpty() && (0 == LinkPropList.Num()))
+        else if ((false == IsSingleCAD()) && WorldName.IsEmpty() && (0 == LinkPropList.Num()))
         {
             if (bIsLogged)
             {
@@ -1636,6 +1654,9 @@ struct RAPYUTASIMULATIONPLUGINS_API FRRRobotModelInfo : public TSharedFromThis<F
 {
 public:
     FRRRobotModelInfo(const FRRRobotModelData& InRobotModelData) : Data(InRobotModelData)
+    {
+    }
+    FRRRobotModelInfo(FRRRobotModelData&& InRobotModelData) : Data(MoveTemp(InRobotModelData))
     {
     }
     FRRRobotModelInfo()


### PR DESCRIPTION
SINGLE_CAD is a description type whereby an entity (robot or object) is imported purely from a single 3D CAD file. In case of robots, only FBX is supported for now.
`ARRBaseRobot` `RobotModelName` to ref `EntityModelName` as both referring to RRBaseActor's model name. It is just kept so to make it clear for robots.
