### PR TITLE
Revert RobotModelName reference to avoid crash in child BP

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Robots/RRBaseRobot.cpp
@@ -151,7 +151,7 @@ void ARRBaseRobot::PreInitializeComponents()
     if (ROSSpawnParameters)
     {
         InitPropertiesFromJSON();
-        RobotModelName = ROSSpawnParameters->ActorModelName;
+        SetRobotModelName(ROSSpawnParameters->ActorModelName);
         RobotUniqueName = ROSSpawnParameters->ActorName;
     }
 

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -272,7 +272,7 @@ public:
 
     //! Robot Model Name (loaded from URDF/SDF)
     UPROPERTY(VisibleAnyWhere, BlueprintReadOnly, meta = (ExposeOnSpawn = "true"), Replicated)
-    FString& RobotModelName = EntityModelName;
+    FString RobotModelName ;
 
     /**
      * @brief Get robot model name

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRBaseRobot.h
@@ -271,13 +271,24 @@ public:
     }
 
     //! Robot Model Name (loaded from URDF/SDF)
+    //! should be same as EntityModelName in #ARRBaseActor
+    //! @todo move to protected member
     UPROPERTY(VisibleAnyWhere, BlueprintReadOnly, meta = (ExposeOnSpawn = "true"), Replicated)
-    FString RobotModelName ;
+    FString RobotModelName;
 
-    /**
-     * @brief Get robot model name
-     */
-    FString GetModelName() const
+    UFUNCTION(BlueprintCallable)
+    virtual void SetRobotModelName(const FString InName)
+    {
+        RobotModelName = InName;
+        EntityModelName = InName;
+        if (ActorInfo.IsValid())
+        {
+            ActorInfo->EntityModelName = InName;
+        }
+    }
+
+    UFUNCTION(BlueprintCallable)
+    virtual FString GetRobotModelName()
     {
         return RobotModelName;
     }


### PR DESCRIPTION
@Tadinu I experienced tb crash when I opened tht Turtlebot3WaffleVehicle in Editor.
Please check next week