### PR TITLE
Add pak loader

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRAssetUtils.cpp
@@ -319,6 +319,9 @@ bool URRAssetUtils::SavePackageToAsset(UPackage* InPackage, UObject* InObject, b
             InObject->Rename(nullptr, InPackage);
         }
 
+        // Make sure [InObject] has RF_Transient cleared
+        InObject->ClearFlags(EObjectFlags::RF_Transient);
+
         // NOTE: [UPackage::Save()] is in-Engine api, while [SavePackageHelper(InPackage, packageFileName))] is in-Editor
         // Use [result] to print error code later
         const FSavePackageResultStruct result = UPackage::Save(InPackage, InObject, *packageFileName, saveArgs);

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
@@ -270,7 +270,7 @@ bool URRCoreUtils::WaitUntilThenAct(TFunctionRef<bool()> InCond,
         // Sleep takes seconds, not msec
         FPlatformProcess::Sleep(InIntervalTimeInSec);
     }
-    // Either InCond() is met or [ElapsedTime] is over [InTimeoutInSec]
+    // Now, either InCond() has been met or [GetElapsedTimeSecs()] is over [InTimeoutInSec]
 
     if (bResult)
     {

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRCoreUtils.cpp
@@ -261,18 +261,16 @@ bool URRCoreUtils::WaitUntilThenAct(TFunctionRef<bool()> InCond,
                                     float InTimeoutInSec,
                                     float InIntervalTimeInSec)
 {
-    FDateTime begin(FDateTime::UtcNow());
-    double elapsed_time = 0;
+    const float startTime = URRCoreUtils::GetSeconds();
     // Wait with a timeout
     bool bResult = false;
-    while (!bResult && elapsed_time < InTimeoutInSec)
+    while (!bResult && (URRCoreUtils::GetElapsedTimeSecs(startTime) < InTimeoutInSec))
     {
         bResult = InCond();
         // Sleep takes seconds, not msec
         FPlatformProcess::Sleep(InIntervalTimeInSec);
-        elapsed_time = FTimespan(FDateTime::UtcNow() - begin).GetTotalSeconds();
     }
-    // Either InCond() is met or [elapsed_ticks] is over [InTimeoutInSec]
+    // Either InCond() is met or [ElapsedTime] is over [InTimeoutInSec]
 
     if (bResult)
     {

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameMode.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameMode.cpp
@@ -45,7 +45,7 @@ void ARRGameMode::PrintSimConfig() const
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("- bBenchmark: %d"), bBenchmark);
 }
 
-void ARRGameMode::PrintUEPreprocessors() const
+void ARRGameMode::PrintUEPreprocessors()
 {
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("UE PREPROCESSORS:"));
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("* [DO_CHECK] %s!"), URRCoreUtils::GetBoolPreprocessorText<DO_CHECK>());
@@ -71,6 +71,11 @@ void ARRGameMode::PrintUEPreprocessors() const
     UE_LOG_WITH_INFO(
         LogRapyutaCore, Display, TEXT("* [WITH_UNREALJPEG] %s!"), URRCoreUtils::GetBoolPreprocessorText<WITH_UNREALJPEG>());
 
+    UE_LOG_WITH_INFO(LogRapyutaCore,
+                     Display,
+                     TEXT("* [USING_THREAD_SANITISER] %s!"),
+                     URRCoreUtils::GetBoolPreprocessorText<USING_THREAD_SANITISER>());
+
 #if (!WITH_EDITOR)
     UE_LOG_WITH_INFO(LogRapyutaCore,
                      Display,
@@ -78,22 +83,14 @@ void ARRGameMode::PrintUEPreprocessors() const
                      FAsyncLoadingThreadSettings::Get().bAsyncLoadingThreadEnabled);
 #endif
 
-    // Fetch [-physxDispatcher]
-    // Ref: UnrealEngine/Engine/Source/Runtime/Engine/Private/PhysicsEngine/PhysScene_PhysX.cpp:1812
-    int8 physXDispatcherNum = 0;
+    // Physics [Single/Multi-threaded mode]
     if (PhysSingleThreadedMode())
     {
-        // UnrealEngine/Engine/Source/Runtime/Engine/Private/PhysicsEngine/PhysScene_PhysX.cpp:1519
         UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN GAME THREAD!"));
-    }
-    else if (URRCoreUtils::GetCommandLineArgumentValue<int8>(URRCoreUtils::CCMDLINE_ARG_INT_PHYSX_DISPATCHER_NUM,
-                                                             physXDispatcherNum))
-    {
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN [%d] THREADS!"), physXDispatcherNum);
     }
     else
     {
-        UE_LOG_WITH_INFO(LogTemp, Display, TEXT("PHYSICS RUNS IN A SINGLE THREAD!"));
+        UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("PHYSICS RUNS IN A MULTI-THREADED MODE!"));
     }
 }
 
@@ -114,13 +111,13 @@ void ARRGameMode::StartPlay()
 {
 #if RAPYUTA_SIM_VERBOSE
     UE_LOG_WITH_INFO(LogRapyutaCore, Display, TEXT("START PLAY!"))
-    PrintSimConfig();
     PrintUEPreprocessors();
 #endif
+    PrintSimConfig();
 
     if (URRGameSingleton::Get() == nullptr)
     {
-        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("GameSingleton is not child class of0 URRGameSingleton."));
+        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("GameSingleton is not child class of URRGameSingleton."));
     }
 
 #if !WITH_EDITOR
@@ -157,9 +154,7 @@ void ARRGameMode::StartSim()
     auto* gameSingleton = URRGameSingleton::Get();
     if (gameSingleton)
     {
-#if RAPYUTA_SIM_VERBOSE
         gameSingleton->PrintSimConfig();
-#endif
         gameSingleton->InitializeResources();
     }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRGameSingleton.cpp
@@ -62,7 +62,7 @@ URRGameSingleton* URRGameSingleton::Get()
     URRGameSingleton* singleton = Cast<URRGameSingleton>(GEngine->GameSingleton);
     if (!singleton)
     {
-        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("NOT YET SET AS GAME SINGLETON!!"));
+        UE_LOG_WITH_INFO(LogRapyutaCore, Warning, TEXT("[GEngine->GameSingletonClassName] IS NOT SET AS [URRGameSingleton]"));
         return nullptr;
     }
 

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRPakLoader.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRPakLoader.cpp
@@ -1,0 +1,135 @@
+// Copyright 2020-2023 Rapyuta Robotics Co., Ltd.
+
+#include "Core/RRPakLoader.h"
+
+// UE
+#include "CoreMinimal.h"
+
+// RapyutaSimulationPlugins
+#include "Core/RRAssetUtils.h"
+#include "Core/RRGameSingleton.h"
+
+// Internal folder name to use as base for the assets found in the mounted PAK files
+// NOTE: This is a hard-coded name defined by UE!
+static constexpr const TCHAR* UE_PAK_MOUNTED_BASE_FOLDER_NAME = TEXT("Paks");
+
+bool URRPakLoader::Initialize()
+{
+#if WITH_EDITOR
+    UE_LOG_WITH_INFO_SHORT(LogRapyutaCore, Warning, TEXT("Pak loader is NOT used in Editor"));
+    return false;
+#else
+    RRGameSingleton = URRGameSingleton::Get();
+    PakManager = static_cast<FPakPlatformFile*>(FPlatformFileManager::Get().FindPlatformFile(FPakPlatformFile::GetTypeName()));
+    if (PakManager)
+    {
+        UE_LOG(LogRapyutaCore, Log, TEXT("Use existing PAK platform"));
+    }
+    else
+    {
+        PakManager = new FPakPlatformFile();
+        if (!PakManager->Initialize(&FPlatformFileManager::Get().GetPlatformFile(), nullptr))
+        {
+            UE_LOG_WITH_INFO_SHORT(LogRapyutaCore, Error, TEXT("Failed to initialize PAK platform"));
+            return false;
+        }
+
+        // [PakManager], in case of already existing, got this done by [FPlatformFileManager::InitializeNewAsyncIO()]
+        PakManager->InitializeNewAsyncIO();
+
+        // Set [PakManager] as [FPlatformFileManager]'s TopmostPlatformFile
+        FPlatformFileManager::Get().SetPlatformFile(*PakManager);
+        UE_LOG(LogRapyutaCore, Log, TEXT("Use custom PAK platform file"));
+    }
+    UE_LOG(LogRapyutaCore, Log, TEXT("[PakManager] initialized"));
+    return true;
+#endif
+}
+
+void URRPakLoader::MountPAKFiles(const TArray<FString>& InPAKPaths)
+{
+    for (const FString& sourcePakPath : InPAKPaths)
+    {
+        UE_LOG(LogRapyutaCore, Log, TEXT("Mount PAK path [%s]"), *sourcePakPath);
+
+        // 0- CREATE a PAK file and check its contents
+        TRefCountPtr<FPakFile> pakFilePtr = new FPakFile(PakManager->GetLowerLevel(), *sourcePakPath, false);
+        FPakFile& pakFile = *pakFilePtr;
+
+        if (false == pakFile.Check())
+        {
+            UE_LOG(LogRapyutaCore, Error, TEXT("Pak file [%s] is invalid"), *sourcePakPath);
+            continue;
+        }
+
+        // NOTE: A pak's original mount point is its author's local PC disk path saved during packing
+        const FString& originalMountPoint = pakFile.GetMountPoint();
+        UE_LOG(LogRapyutaCore, Log, TEXT("- Original mount point: %s"), *originalMountPoint);
+        FString pakFolderRelPath;
+        originalMountPoint.Split(FApp::GetProjectName(), nullptr, &pakFolderRelPath);
+
+        // 1- MOUNT the Pak at the exactly same relative location under package dir
+        // NOTE: [FPaths::ProjectDir()] is also package dir.
+        // This is a mount point, thus must not use [FPaths::ConvertRelativePathToFull()]
+        const FString newMountPoint = FPaths::RemoveDuplicateSlashes(FPaths::ProjectDir() / pakFolderRelPath);
+        UE_LOG(LogRapyutaCore, Log, TEXT("- New mount point: %s"), *newMountPoint);
+
+        pakFile.SetMountPoint(*newMountPoint);
+        if (!PakManager->Mount(*sourcePakPath, 0, *newMountPoint))
+        {
+            UE_LOG(LogRapyutaCore, Error, TEXT("Failed to mount package [%s] on [%s]"), *sourcePakPath, *newMountPoint);
+            continue;
+        }
+#if RAPYUTA_SIM_DEBUG
+        // NOTE: This is not needed, only kept for ref
+        FPackageName::RegisterMountPoint(TEXT("/Game/"), newMountPoint);
+#endif
+
+        // 2- VERIFY Pak contents' mounted paths
+        // THESE MOUNTED RESOURCE-PATHS ARE THEN CONVERTED TO SOFT-OBJECT-PATHS as BEING LOADED BY [AssetManager's FStreamableManager]
+        // -> THUS STARTING FROM PACKAGE DIR, THEY MUST BE EXACTLY THE SAME AS IN THE PROJECT DIR WHEN BEING PACKED.
+        // EG: <PackageDir>/Plugins/<PluginDir>/Content/DynamicContents/<ResourceTypeDir>/<ResourceFile>
+        TArray<FString> pakContentPathList;
+        pakFile.FindPrunedFilesAtPath(pakContentPathList, *pakFile.GetMountPoint(), true, false, true);
+        UE_LOG(LogRapyutaCore, Display, TEXT("[%s] has been mounted to files:"), *sourcePakPath);
+        for (const auto& resourceMountedPath : pakContentPathList)
+        {
+            UE_LOG(LogRapyutaCore, Log, TEXT("- [%s]"), *FPaths::ConvertRelativePathToFull(resourceMountedPath));
+        }
+    }
+
+    // 3- Force rescan of all assets after mounting PAKs -> assets
+    URRAssetUtils::GetAssetRegistry().ScanPathsSynchronous(
+        URRGameSingleton::GetDynamicAssetsBasePathList(ERRResourceDataType::UE_PAK), true);
+
+#if RAPYUTA_SIM_VERBOSE
+    TArray<FString> allAssetPaths;
+    URRAssetUtils::GetAssetRegistry().GetAllCachedPaths(allAssetPaths);
+
+    UE_LOG_WITH_INFO_SHORT(LogRapyutaCore, Warning, TEXT("All PAK-mounted asset paths fetched from AssetRegistry"));
+    for (const FString& path : allAssetPaths)
+    {
+        UE_LOG(LogRapyutaCore, Warning, TEXT("- %s"), *path);
+    }
+#endif
+}
+
+bool URRPakLoader::LoadPAKFiles(const FString& InPakFolderPath)
+{
+    if (!ensure(PakManager))
+    {
+        UE_LOG_WITH_INFO_SHORT(LogRapyutaCore, Error, TEXT("PakManager seems not yet initialized"));
+        return false;
+    }
+
+    // FETCH [pakPaths] & MOUNT TO FILES ON DISK
+    TArray<FString> pakPaths;
+    if (URRCoreUtils::LoadFullFilePaths(InPakFolderPath, pakPaths, {ERRFileType::PAK}))
+    {
+        UE_LOG(LogRapyutaCore, Log, TEXT("Found %d paks in folder [%s]"), pakPaths.Num(), *InPakFolderPath);
+
+        // MOUNT [pakPaths]
+        MountPAKFiles(pakPaths);
+    }
+    return true;
+}

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRPakLoader.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRPakLoader.cpp
@@ -9,10 +9,6 @@
 #include "Core/RRAssetUtils.h"
 #include "Core/RRGameSingleton.h"
 
-// Internal folder name to use as base for the assets found in the mounted PAK files
-// NOTE: This is a hard-coded name defined by UE!
-static constexpr const TCHAR* UE_PAK_MOUNTED_BASE_FOLDER_NAME = TEXT("Paks");
-
 bool URRPakLoader::Initialize()
 {
 #if WITH_EDITOR

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRSceneDirector.cpp
@@ -120,7 +120,7 @@ void ARRSceneDirector::OnDataCollectionPhaseDone(bool bIsFinalDataCollectingPhas
             UE_LOG_WITH_SCENE_ID(LogRapyutaCore,
                                  Log,
                                  TEXT("DATA COLLECTION DONE - TOOK [%lf] secs!"),
-                                 URRCoreUtils::GetElapsedTime(DataCollectionTimeStamp));
+                                 URRCoreUtils::GetElapsedTimeSecs(DataCollectionTimeStamp));
         }
     }
 }

--- a/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Core/RRStaticMeshComponent.cpp
@@ -333,10 +333,8 @@ UStaticMesh* URRStaticMeshComponent::CreateMeshBody(const FRRMeshData& InMeshDat
     {
         if (visualMesh->GetSourceModel(0).IsMeshDescriptionValid())
         {
-#endif
             URRAssetUtils::SaveObjectToAssetInModule(
                 visualMesh, ERRResourceDataType::UE_STATIC_MESH, MeshUniqueName, RAPYUTA_SIMULATION_PLUGINS_MODULE_NAME);
-#if WITH_EDITOR
         }
         else
         {

--- a/Source/RapyutaSimulationPlugins/Private/Tools/OccupancyMapGenerator.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Tools/OccupancyMapGenerator.cpp
@@ -2,12 +2,17 @@
 
 #include "Tools/OccupancyMapGenerator.h"
 
+// UE
 #include "DrawDebugHelpers.h"
 #include "HAL/PlatformFileManager.h"
+#include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 #include "logUtilities.h"
 #include "RapyutaSimulationPlugins.h"
 #include "Misc/FileHelper.h"
+
+// RapyutaSimulationPlugins
+#include "RapyutaSimulationPlugins.h"
 
 // Sets default values
 AOccupancyMapGenerator::AOccupancyMapGenerator()

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -44,63 +44,6 @@ class ARRMeshActor;
 class ARRCamera;
 class URRCoreUtils;
 
-/**
- * @brief todo
- *
- */
-UENUM()
-enum class ERRFileType : uint8
-{
-    NONE,
-    UASSET,    // UE Asset file
-    INI,
-    YAML,
-
-    // Image
-    IMAGE_JPG,
-    IMAGE_GRAYSCALE_JPG,
-    IMAGE_PNG,
-    IMAGE_TGA,
-    IMAGE_EXR,
-    IMAGE_HDR,
-
-    // Light Profile
-    LIGHT_PROFILE_IES,
-
-    // Meta Data
-    JSON,
-
-    // 3D Description Format
-    URDF,
-    SDF,
-    GAZEBO_WORLD,
-    MJCF,    // MuJoCo
-
-    // 3D CAD
-    CAD_FBX,
-    CAD_OBJ,
-    CAD_STL,
-    CAD_DAE,
-    TOTAL
-};
-
-/**
- * @brief todo
- *
- */
-UENUM()
-enum class ERRShapeType : uint8
-{
-    NONE,
-    PLANE,
-    BOX,
-    CYLINDER,
-    SPHERE,
-    CAPSULE,
-    MESH,
-    TOTAL
-};
-
 USTRUCT()
 struct RAPYUTASIMULATIONPLUGINS_API FRRStreamingLevelInfo
 {

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRActorCommon.h
@@ -545,7 +545,6 @@ public:
     static void OnPostWorldCleanup(UWorld* InWorld, bool /*bInSessionEnded*/, bool /*bInCleanupResources*/);
 
 public:
-#define EMPTY_STR (TEXT(""))    // Using TCHAR* = TEXT("") -> could causes linking error in some case!
     static constexpr const TCHAR* SPACE_STR = TEXT(" ");
     static constexpr const TCHAR* DELIMITER_STR = TEXT(",");
     static constexpr const TCHAR* UNDERSCORE_STR = TEXT("_");

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRAssetUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRAssetUtils.h
@@ -249,7 +249,7 @@ public:
         }
 
         objectLibrary->GetAssetDataList(OutAssetDataList);
-        verify(IsAssetDataListValid(OutAssetDataList, bIsFullLoad, true));
+        ensure(IsAssetDataListValid(OutAssetDataList, bIsFullLoad, true));
     }
 
     /**

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
@@ -124,6 +124,7 @@ public:
         TEXT(""),    // ERRFileType::NONE
         // UE & General
         TEXT(".uasset"),    // ERRFileType::UASSET
+        TEXT(".pak"),       // ERRFileType::PAK
         TEXT(".ini"),       // ERRFileType::INI
         TEXT(".yaml"),      // ERRFileType::YAML
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
@@ -623,16 +623,16 @@ public:
     static TMap<ERRFileType, TSharedPtr<IImageWrapper>> SImageWrappers;
     static void LoadImageWrapperModule();
 
-    FORCEINLINE static UTexture2D* LoadImageToTexture(const FString& InFullFilePath, const FString& InTextureName)
-    {
-        UTexture2D* loadedTexture = FImageUtils::ImportFileAsTexture2D(InFullFilePath);
-        if (loadedTexture)
-        {
-            loadedTexture->Rename(*InTextureName);
-        }
-
-        return loadedTexture;
-    }
+    /**
+     * @brief Load image to texture
+     * @param InFullFilePath
+     * @param InTextureName
+     * @param bInSaveToAsset if True -> use ImportObject(), otherwise FImageUtils::ImportFileAsTexture2D()
+     * @return UTexture2D*
+     */
+    static UTexture2D* LoadImageToTexture(const FString& InFullFilePath,
+                                          const FString& InTextureName,
+                                          const bool bInSaveToAsset = false);
 
     static bool LoadImagesFromFolder(const FString& InImageFolderPath,
                                      const TArray<ERRFileType>& InImageFileTypes,

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
@@ -620,12 +620,14 @@ public:
     // -------------------------------------------------------------------------------------------------------------------------
     // PROCESS UTILS --
     //
-    static int32 RunMonitoredProcess(FMonitoredProcess* InProcess, const float InTimeOutSecs)
+    static int32 RunMonitoredProcess(FMonitoredProcess* InProcess,
+                                     const float InTimeOutSecs,
+                                     const FString& InProcessName = EMPTY_STR)
     {
         // Launch [InProcess]
         if (false == InProcess->Launch())
         {
-            UE_LOG_WITH_INFO_SHORT(LogTemp, Error, TEXT("Failed launching process"));
+            UE_LOG_WITH_INFO_SHORT(LogTemp, Error, TEXT("[%s] Process failed being launched"), *InProcessName);
             return -1;
         }
 
@@ -636,6 +638,11 @@ public:
             // Already slept in [Update()]
             if (URRCoreUtils::GetElapsedTimeSecs(lastMarkedTime) > InTimeOutSecs)
             {
+                UE_LOG_WITH_INFO(LogTemp,
+                                 Error,
+                                 TEXT("[%s] Process is about to be terminated after timeout [%f secs]"),
+                                 *InProcessName,
+                                 InTimeOutSecs);
                 InProcess->Cancel();
             }
         }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
@@ -201,8 +201,6 @@ public:
 
 // SIM COMMAND LINE EXECUTION --
 #define CCMDLINE_ARG_FORMAT (TEXT("%s="))
-    static constexpr const TCHAR* CCMDLINE_ARG_INT_PHYSX_DISPATCHER_NUM = TEXT("physxDispatcher");
-
     template<typename TCmdlet>
     static bool IsRunningSimCommandlet()
     {
@@ -633,16 +631,20 @@ public:
 
         // Wait for it to finish with [InTimeOutSecs]
         const float lastMarkedTime = URRCoreUtils::GetSeconds();
+        bool bCancelled = false;
         while (InProcess->Update())
         {
             // Already slept in [Update()]
-            if (URRCoreUtils::GetElapsedTimeSecs(lastMarkedTime) > InTimeOutSecs)
+            if ((!bCancelled) && (URRCoreUtils::GetElapsedTimeSecs(lastMarkedTime) > InTimeOutSecs))
             {
+                bCancelled = true;
                 UE_LOG_WITH_INFO(LogTemp,
                                  Error,
                                  TEXT("[%s] Process is about to be terminated after timeout [%f secs]"),
                                  *InProcessName,
                                  InTimeOutSecs);
+
+                // NOTE: This would trigger process cancelling, which should be waited for completion before this while loop exits
                 InProcess->Cancel();
             }
         }

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRCoreUtils.h
@@ -32,6 +32,7 @@
 
 // RapyutaSimulationPlugins
 #include "Core/RRActorCommon.h"
+#include "Core/RRGeneralUtils.h"
 #include "Core/RRTextureData.h"
 #include "Core/RRTypeUtils.h"
 

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameMode.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameMode.h
@@ -99,9 +99,19 @@ public:
      */
     virtual void StartPlay() override;
 
+    /**
+     * @brief Print GameMode's user configs in INI
+     */
     virtual void PrintSimConfig() const;
-    virtual void PrintUEPreprocessors() const;
 
+    /**
+     * @brief Print UE global preprocessors' values
+     */
+    static void PrintUEPreprocessors();
+
+    /**
+     * @brief Config Sim global configs in prep for play
+     */
     virtual void ConfigureSimInPlay();
 
     /**

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -21,11 +21,14 @@
 // RapyutaSimulationPlugins
 #include "Core/RRActorCommon.h"
 #include "Core/RRAssetUtils.h"
+#include "Core/RRGeneralUtils.h"
 #include "Core/RRObjectCommon.h"
 #include "Core/RRTypeUtils.h"
 #include "RapyutaSimulationPlugins.h"
 
 #include "RRGameSingleton.generated.h"
+
+class URRPakLoader;
 
 template<const ERRResourceDataType InDataType>
 using URRAssetObject = typename TChooseClass<
@@ -94,15 +97,23 @@ public:
      */
     void FinalizeResources();
 
+    // PAKS --
+    UPROPERTY(Config)
+    FString FOLDER_PATH_ASSET_PAKS = TEXT("Paks");
+    UPROPERTY()
+    TObjectPtr<URRPakLoader> PakLoader = nullptr;
+
     // ASSETS --
     //! This list specifically hosts names of which module houses the UE assets based on their data type
     static TMap<ERRResourceDataType, TArray<const TCHAR*>> SASSET_OWNING_MODULE_NAMES;
 
-    //! This only returns base path of assets residing in Plugin, not from Project level, which should starts with [/Game/]
-    //! And please note that the Sim does not store assets in Project, just to make them accessible among plugins.
+    //! [ASSETS_ROOT_PATH] only returns base path of assets residing in Plugin, not from Project level, which should starts with [/Game/]
+    //! And ideally, Sim should not store common runtime-created assets in Project, since they should be accessible among plugins.
     static constexpr const TCHAR* ASSETS_ROOT_PATH = TEXT("/");
+    static constexpr const TCHAR* ASSETS_PROJECT_BASE_MODULE_NAME = TEXT("Game");
     static constexpr const TCHAR* ASSETS_PROJECT_MODULE_NAME = TEXT("Game/RapyutaContents");
 
+    //! Base path whereby runtime-created blueprint classes are saved, ideally in Project, so it could reference all plugins' assets.
     UPROPERTY(Config)
     FString ASSETS_RUNTIME_BP_SAVE_BASE_PATH = TEXT("/Game/RapyutaContents/Blueprints");
 
@@ -178,6 +189,9 @@ public:
     {
         switch (InDataType)
         {
+            case ERRResourceDataType::UE_PAK:
+                return FOLDER_PATH_ASSET_PAKS;
+
             case ERRResourceDataType::UE_STATIC_MESH:
                 return FOLDER_PATH_ASSET_STATIC_MESHES;
 
@@ -274,13 +288,13 @@ public:
         for (const auto& asset : totalAssetDataList)
         {
 #if RAPYUTA_SIM_DEBUG
-            UE_LOG_WITH_INFO(LogTemp,
-                             Warning,
-                             TEXT("[%s] ASSET [%s] [%s]"),
-                             *asset.AssetName.ToString(),
-                             *asset.PackagePath.ToString(),
-                             *asset.GetFullName(),
-                             *asset.ToSoftObjectPath().ToString());
+            UE_LOG_WITH_INFO_SHORT(LogTemp,
+                                   Warning,
+                                   TEXT("[%s] ASSET [%s] [%s] [%s]"),
+                                   *asset.AssetName.ToString(),
+                                   *asset.PackagePath.ToString(),
+                                   *asset.GetFullName(),
+                                   *asset.ToSoftObjectPath().ToString());
 #endif
             outResourceInfo.AddResource(asset.AssetName.ToString(), asset.ToSoftObjectPath().ToString(), nullptr);
         }
@@ -316,7 +330,8 @@ public:
         }
 
         // 1- COLLATE ALL ASSETS INFO
-        if (0 == CollateAssetsInfo<URRAssetObject<InDataType>>(InDataType, GetAssetsFolderName(InDataType)))
+        int32 assetsNum = CollateAssetsInfo<URRAssetObject<InDataType>>(InDataType, GetAssetsFolderName(InDataType));
+        if (0 == assetsNum)
         {
             resourceInfo.bHasBeenAllLoaded = true;
             UE_LOG_WITH_INFO(
@@ -435,7 +450,7 @@ public:
 #if RAPYUTA_SIM_DEBUG
             UE_LOG_WITH_INFO(LogTemp,
                              Warning,
-                             TEXT("%d [%s] [%s:%s] RESOURCE LOADED %d"),
+                             TEXT("%d [%s] [%s:%s] RESOURCE LOADED %u"),
                              resourceInfo.ToBeAsyncLoadedResourceNum,
                              *URRTypeUtils::GetERRResourceDataTypeAsString(InDataType),
                              *InResourceUniqueName,

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGameSingleton.h
@@ -330,8 +330,7 @@ public:
         }
 
         // 1- COLLATE ALL ASSETS INFO
-        int32 assetsNum = CollateAssetsInfo<URRAssetObject<InDataType>>(InDataType, GetAssetsFolderName(InDataType));
-        if (0 == assetsNum)
+        if (0 == CollateAssetsInfo<URRAssetObject<InDataType>>(InDataType, GetAssetsFolderName(InDataType)))
         {
             resourceInfo.bHasBeenAllLoaded = true;
             UE_LOG_WITH_INFO(

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRGeneralUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRGeneralUtils.h
@@ -14,6 +14,9 @@
 
 #include "RRGeneralUtils.generated.h"
 
+// NOTE: Using TCHAR* = TEXT("") -> could cause linking error in some case!
+#define EMPTY_STR (TEXT(""))
+
 /**
  * @brief General utils
  *

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
@@ -83,6 +83,7 @@ enum class ERRResourceDataType : uint8
 {
     NONE,
     // UASSET --
+    UE_PAK,
     UE_STATIC_MESH,
     UE_SKELETAL_MESH,
     UE_SKELETON,

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRObjectCommon.h
@@ -19,6 +19,62 @@
 // Note: For avoiding cyclic inclusion, only UE built-in source header files could be included herein.
 
 /**
+ * @brief File types
+ */
+UENUM()
+enum class ERRFileType : uint8
+{
+    NONE,
+    UASSET,    // UE Asset file
+    PAK,
+    INI,
+    YAML,
+
+    // Image
+    IMAGE_JPG,
+    IMAGE_GRAYSCALE_JPG,
+    IMAGE_PNG,
+    IMAGE_TGA,
+    IMAGE_EXR,
+    IMAGE_HDR,
+
+    // Light Profile
+    LIGHT_PROFILE_IES,
+
+    // Meta Data
+    JSON,
+
+    // 3D Description Format
+    URDF,
+    SDF,
+    GAZEBO_WORLD,
+    MJCF,    // MuJoCo
+
+    // 3D CAD
+    CAD_FBX,
+    CAD_OBJ,
+    CAD_STL,
+    CAD_DAE,
+    TOTAL
+};
+
+/**
+ * @brief Shape types
+ */
+UENUM()
+enum class ERRShapeType : uint8
+{
+    NONE,
+    PLANE,
+    BOX,
+    CYLINDER,
+    SPHERE,
+    CAPSULE,
+    MESH,
+    TOTAL
+};
+
+/**
  * @brief Sim resource(Uassets) data types
  *
  */

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRPakLoader.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRPakLoader.h
@@ -1,0 +1,55 @@
+/**
+ * @file RRPakLoader.h
+ * @brief Pak loader
+ * @copyright Copyright 2020-2023 Rapyuta Robotics Co., Ltd.
+ */
+
+#pragma once
+
+// UE
+#include "IPlatformFilePak.h"
+
+// RapyutaSimulationPlugins
+#include "RapyutaSimulationPlugins.h"
+
+#include "RRPakLoader.generated.h"
+
+class URRGameSingleton;
+
+/**
+ * @brief Pak loader
+ * - Load pak files into [FPakPlatformFile](https://docs.unrealengine.com/5.2/en-US/API/Runtime/PakFile/FPakPlatformFile)
+ * - Mount pak contents (as cooked resource assets) to a folder to be early loaded by URRGameSingleton during sim initialization
+ */
+UCLASS()
+class RAPYUTASIMULATIONPLUGINS_API URRPakLoader : public UObject
+{
+    GENERATED_BODY()
+public:
+    /**
+     * @brief Initialize #PakManager
+     * @return true/false
+     */
+    bool Initialize();
+
+    /**
+     * @brief Load PAK files
+     * @param InPakFolderPath
+     */
+    UFUNCTION()
+    bool LoadPAKFiles(const FString& InPakFolderPath);
+
+private:
+    //! Pak file manager, responsible for loading & mounting paks
+    FPakPlatformFile* PakManager = nullptr;
+
+    UPROPERTY()
+    TObjectPtr<URRGameSingleton> RRGameSingleton = nullptr;
+
+    /**
+     * @brief Mount PAK paths to files on disk
+     * @param InPAKPaths
+     */
+    UFUNCTION()
+    void MountPAKFiles(const TArray<FString>& InPAKPaths);
+};

--- a/Source/RapyutaSimulationPlugins/Public/Core/RRUObjectUtils.h
+++ b/Source/RapyutaSimulationPlugins/Public/Core/RRUObjectUtils.h
@@ -15,6 +15,7 @@
 #include "Core/RRActorCommon.h"
 #include "Core/RRCoreUtils.h"
 #include "Core/RRGameState.h"
+#include "Core/RRGeneralUtils.h"
 #include "Core/RRTextureData.h"
 #include "Core/RRThreadUtils.h"
 

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
@@ -1060,6 +1060,11 @@ public:
     {
         return (ERRUEComponentType::WHEEL_DRIVE == static_cast<ERRUEComponentType>(UEComponentTypeFlags));
     }
+    bool HasDriveComponents() const
+    {
+        return IsUEComponentEnabled(static_cast<int32>(ERRUEComponentType::ARTICULATION_DRIVE | ERRUEComponentType::DIFF_DRIVE |
+                                                       ERRUEComponentType::WHEEL_DRIVE));
+    }
 
     // Link/Joint list
     UPROPERTY(EditAnywhere)
@@ -1715,6 +1720,10 @@ public:
     FORCEINLINE bool IsPlainWheeledVehicleModel() const
     {
         return Data.IsPlainWheeledVehicleModel();
+    }
+    FORCEINLINE bool HasDriveComponents() const
+    {
+        return Data.HasDriveComponents();
     }
 
     // Link/Joint list

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
@@ -1066,6 +1066,16 @@ public:
                                                        ERRUEComponentType::WHEEL_DRIVE));
     }
 
+    bool IsRobotModel() const
+    {
+        return HasDriveComponents();
+    }
+
+    bool IsObjectModel() const
+    {
+        return (false == IsRobotModel());
+    }
+
     // Link/Joint list
     UPROPERTY(EditAnywhere)
     FString BaseLinkName;
@@ -1721,9 +1731,13 @@ public:
     {
         return Data.IsPlainWheeledVehicleModel();
     }
-    FORCEINLINE bool HasDriveComponents() const
+    FORCEINLINE bool IsRobotModel() const
     {
-        return Data.HasDriveComponents();
+        return Data.IsRobotModel();
+    }
+    FORCEINLINE bool IsObjectModel() const
+    {
+        return Data.IsObjectModel();
     }
 
     // Link/Joint list

--- a/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
+++ b/Source/RapyutaSimulationPlugins/Public/Robots/RRRobotStructs.h
@@ -1068,7 +1068,7 @@ public:
 
     bool IsRobotModel() const
     {
-        return HasDriveComponents();
+        return (JointPropList.Num() > 0) || HasDriveComponents();
     }
 
     bool IsObjectModel() const

--- a/Source/RapyutaSimulationPlugins/RapyutaSimulationPlugins.Build.cs
+++ b/Source/RapyutaSimulationPlugins/RapyutaSimulationPlugins.Build.cs
@@ -44,8 +44,9 @@ public class RapyutaSimulationPlugins : ModuleRules
         bEnableExceptions = true;
 
         // Runtime modules
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "Renderer", "RHI", "PhysicsCore", "XmlParser", "IESFile",
-                                                            "AIModule", "NavigationSystem", "TimeManagement", "Json", "UMG",
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "RenderCore", "Renderer", "RHI", "PhysicsCore",
+                                                            "ImageWrapper", "XmlParser", "Json", "PakFile", "IESFile",
+                                                            "AIModule", "NavigationSystem", "TimeManagement", "UMG",
                                                             "ChaosVehicles",
                                                             "ProceduralMeshComponent", "MeshDescription", "StaticMeshDescription", "MeshConversion",
                                                             "rclUE"});


### PR DESCRIPTION
* `ERRFileType` add PAK
* Add `URRPakLoader`, loading pak files (compressed cooked assets) from `/Game/RapyutaContents/DynamicContents/Paks`, only used in packaged build
* Move EMPTY_STR from ActorCommon to RRGeneralUtils.h to be more decoupling
* Move `ERRFileType & ERRShapeType` from ActorCommon -> ObjectCommon as usable by any generic object
* `URRAssetUtils::SavePackageToAsset()` clear `RF_Transient`, which is not allowed for an object being saved to uasset
* `URRCoreUtils::LoadImageToTexture()` add `bInSaveToAsset`, using `ImportObject()` to import texture if to be saved to uasset, since `FImageUtils::ImportFileAsTexture2D()` only creates a transient non-source-data texture2d that is ineligible to be saved to uasset.