### PR TITLE
add DrawPointIntensity

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RR2DLidarComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RR2DLidarComponent.cpp
@@ -159,7 +159,7 @@ void URR2DLidarComponent::SensorUpdate()
                         LineBatcher->DrawPoint(h.ImpactPoint,
                                                InterpColorFromIntensity(GetIntensityFromDist(IntensityReflective, Distance)),
                                                5,
-                                               10,
+                                               DrawPointDepthIntensity,
                                                Dt);
                     }
                     // non reflective material
@@ -170,7 +170,7 @@ void URR2DLidarComponent::SensorUpdate()
                         LineBatcher->DrawPoint(h.ImpactPoint,
                                                InterpColorFromIntensity(GetIntensityFromDist(IntensityNonReflective, Distance)),
                                                5,
-                                               10,
+                                               DrawPointDepthIntensity,
                                                Dt);
                     }
                     // reflective material
@@ -196,7 +196,7 @@ void URR2DLidarComponent::SensorUpdate()
                                 NormalAlignment * (IntensityReflective - IntensityNonReflective) + IntensityNonReflective,
                                 Distance)),
                             5,
-                            10,
+                            DrawPointDepthIntensity,
                             Dt);
                     }
                 }
@@ -204,14 +204,17 @@ void URR2DLidarComponent::SensorUpdate()
                 {
                     // UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("no physics material"));
                     // LineBatcher->DrawLine(h.TraceStart, h.ImpactPoint, ColorHit, 10, .5, dt);
-                    LineBatcher->DrawPoint(
-                        h.ImpactPoint, InterpColorFromIntensity(GetIntensityFromDist(IntensityNonReflective, Distance)), 5, 10, Dt);
+                    LineBatcher->DrawPoint(h.ImpactPoint,
+                                           InterpColorFromIntensity(GetIntensityFromDist(IntensityNonReflective, Distance)),
+                                           5,
+                                           DrawPointDepthIntensity,
+                                           Dt);
                 }
             }
             else if (ShowLidarRayMisses)
             {
                 // LineBatcher->DrawLine(h.TraceStart, h.TraceEnd, ColorMiss, 10, .25, dt);
-                LineBatcher->DrawPoint(h.TraceEnd, ColorMiss, 2.5, 10, Dt);
+                LineBatcher->DrawPoint(h.TraceEnd, ColorMiss, 2.5, DrawPointDepthIntensity, Dt);
             }
         }
     }

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RR3DLidarComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RR3DLidarComponent.cpp
@@ -165,7 +165,7 @@ void URR3DLidarComponent::SensorUpdate()
                         LineBatcher->DrawPoint(h.ImpactPoint,
                                                InterpColorFromIntensity(GetIntensityFromDist(IntensityReflective, Distance)),
                                                5,
-                                               10,
+                                               DrawPointDepthIntensity,
                                                Dt);
                     }
                     // non reflective material
@@ -176,7 +176,7 @@ void URR3DLidarComponent::SensorUpdate()
                         LineBatcher->DrawPoint(h.ImpactPoint,
                                                InterpColorFromIntensity(GetIntensityFromDist(IntensityNonReflective, Distance)),
                                                5,
-                                               10,
+                                               DrawPointDepthIntensity,
                                                Dt);
                     }
                     // reflective material
@@ -202,7 +202,7 @@ void URR3DLidarComponent::SensorUpdate()
                                 NormalAlignment * (IntensityReflective - IntensityNonReflective) + IntensityNonReflective,
                                 Distance)),
                             5,
-                            10,
+                            DrawPointDepthIntensity,
                             Dt);
                     }
                 }
@@ -210,14 +210,17 @@ void URR3DLidarComponent::SensorUpdate()
                 {
                     // UE_LOG_WITH_INFO(LogTemp, Warning, TEXT("no physics material"));
                     // LineBatcher->DrawLine(h.TraceStart, h.ImpactPoint, ColorHit, 10, .5, dt);
-                    LineBatcher->DrawPoint(
-                        h.ImpactPoint, InterpColorFromIntensity(GetIntensityFromDist(IntensityNonReflective, Distance)), 5, 10, Dt);
+                    LineBatcher->DrawPoint(h.ImpactPoint,
+                                           InterpColorFromIntensity(GetIntensityFromDist(IntensityNonReflective, Distance)),
+                                           5,
+                                           DrawPointDepthIntensity,
+                                           Dt);
                 }
             }
             else if (ShowLidarRayMisses)
             {
                 // LineBatcher->DrawLine(h.TraceStart, h.TraceEnd, ColorMiss, 10, .25, dt);
-                LineBatcher->DrawPoint(h.TraceEnd, ColorMiss, 2.5, 10, Dt);
+                LineBatcher->DrawPoint(h.TraceEnd, ColorMiss, 2.5, DrawPointDepthIntensity, Dt);
             }
         }
     }

--- a/Source/RapyutaSimulationPlugins/Public/Sensors/RRBaseLidarComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Sensors/RRBaseLidarComponent.h
@@ -130,6 +130,11 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     bool ShowLidarRayMisses = false;
 
+    //! DepthIntesity of DrawPoint
+    //! @sa https://docs.unrealengine.com/4.27/en-US/API/Runtime/Engine/Components/ULineBatchComponent/DrawPoint/
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    uint8 DrawPointDepthIntensity = 0;
+
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Intensity")
     float IntensityNonReflective = 1000.f;
 


### PR DESCRIPTION
Add DrawPointDepthIntensity as a parameter for lidar to avoid always drawing lidar point in front of all object.
issue
https://github.com/rapyuta-robotics/turtlebot3-UE/issues/73