### PR TITLE
remvoe owner registeration from 3d lidar scan

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RR3DLidarComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RR3DLidarComponent.cpp
@@ -62,7 +62,7 @@ void URR3DLidarComponent::Run()
 void URR3DLidarComponent::SensorUpdate()
 {
     // complex collisions: true
-    FCollisionQueryParams TraceParams = FCollisionQueryParams(TEXT("3DLaser_Trace"), true, GetOwner());
+    FCollisionQueryParams TraceParams = FCollisionQueryParams(TEXT("3DLaser_Trace"), true);
     TraceParams.bReturnPhysicalMaterial = true;
 
     // TraceParams.bIgnoreTouches = true;


### PR DESCRIPTION
if owner is given, that is automatically ignored by lidar scan.
make it optional same as 2d lidar

issue: https://github.com/rapyuta-robotics/RapyutaSimulationPlugins/issues/203