### PR TITLE
fix (RRROS2IMUComponent.cpp): make gravity vector of IMU follow standard

### DIFF
--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2IMUComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2IMUComponent.cpp
@@ -82,7 +82,7 @@ void URRROS2IMUComponent::SensorUpdate()
         {
             FVector GravityAcc =
                 FVector(0.0, 0.0, -UnitConversion::ForceUnificationFactor(EUnit::KilogramsForce) * 100);    // cm/ss
-            linearAcc += worldTransform.GetRotation().UnrotateVector(GravityAcc);
+            linearAcc -= worldTransform.GetRotation().UnrotateVector(GravityAcc);
         }
         linearAcc *= AccGain;
 

--- a/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2IMUComponent.cpp
+++ b/Source/RapyutaSimulationPlugins/Private/Sensors/RRROS2IMUComponent.cpp
@@ -82,6 +82,8 @@ void URRROS2IMUComponent::SensorUpdate()
         {
             FVector GravityAcc =
                 FVector(0.0, 0.0, -UnitConversion::ForceUnificationFactor(EUnit::KilogramsForce) * 100);    // cm/ss
+            // Gravity vector points towards Z(+) axis
+            // reference: https://base.movella.com/s/article/Why-does-an-accelerometer-measure-gravity-with-positive-sign?
             linearAcc -= worldTransform.GetRotation().UnrotateVector(GravityAcc);
         }
         linearAcc *= AccGain;


### PR DESCRIPTION
The expected signal for the gravity vector when read through IMU is upwards, such as the example image

![image](https://github.com/user-attachments/assets/7aeb5c37-0a69-475e-b625-aa3976c1cee5)

I think it should be better to keep the negative sign as default.

Source:[Why does an accelerometer measure gravity with positive sign?](https://base.movella.com/s/article/Why-does-an-accelerometer-measure-gravity-with-positive-sign?language=en_US)
