### PR TITLE
feat: support actual depth image with 32FC1 datatype

### DIFF
--- a/Source/RapyutaSimulationPlugins/Public/Sensors/RRROS2CameraComponent.h
+++ b/Source/RapyutaSimulationPlugins/Public/Sensors/RRROS2CameraComponent.h
@@ -30,6 +30,7 @@ struct FRenderRequest
 {
     GENERATED_BODY()
     TArray<FColor> Image;
+    TArray<FFloat16Color> Depth;
     FRenderCommandFence RenderFence;
 };
 
@@ -116,7 +117,7 @@ public:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     bool Render = true;
-   
+
     // ROS
     /**
      * @brief Update ROS 2 Msg structure from #RenderRequestQueue
@@ -132,7 +133,4 @@ public:
      * @param InMessage
      */
     virtual void SetROS2Msg(UROS2GenericMsg* InMessage) override;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FString Encoding = TEXT("rgb8");
 };


### PR DESCRIPTION
- Add separate processing for RGB and Depth camera types with specific capture source and image properties.
- Introduce new data structures to handle RGB and Depth surface contexts.
- Adjust pixel format and data handling based on camera type, including custom encoding and image data initialization.
- Improve conditions for processing captured data by ensuring proper checks are in place for RGB and Depth data retrieval.
- Add a `Depth` array to `FRenderRequest` struct to store depth information.